### PR TITLE
Make sure compilation on macos will find zlib (from Xcode)

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -77,6 +77,15 @@ pub fn compile_source(version: &Version) -> Result<()> {
             env::set_var("CPPFLAGS", format!("-I{}/include", openssl_prefix));
             env::set_var("LDFLAGS", format!("-L{}/lib", openssl_prefix));
         };
+
+        // Make sure compilation can find zlib
+        // See https://github.com/pyenv/pyenv/wiki/common-build-problems#build-failed-error-the-python-zlib-extension-was-not-compiled-missing-the-zlib
+        let macos_sdk_path = Exec::cmd("xcrun")
+            .arg("--show-sdk-path")
+            .stdout(Redirection::Pipe)
+            .capture()?
+            .stdout_str();
+        env::set_var("CFLAGS", format!("-I{}/usr/include", macos_sdk_path.trim()));
     }
 
     run_cmd_template(&version, "[3/5] Configure", "./configure", &configure_args)?;


### PR DESCRIPTION
If zlib is not found, pip is not compiled (!). Compilation "succeeded" (returned 0) but logs revealed the error.

Set `CFLAGS` to point to xcode's zlib. Since Python is compiled using xcode anyway, we simply use it here.

See https://github.com/pyenv/pyenv/wiki/common-build-problems#build-failed-error-the-python-zlib-extension-was-not-compiled-missing-the-zlib