### PR TITLE
Fix rust version to 1.31.1 in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,7 @@ environment:
     # MSVC
     # - TARGET: i686-pc-windows-msvc
     - TARGET: x86_64-pc-windows-msvc
+      RUST_VERSION: 1.31.1
 
     # # Testing other channels
     # - TARGET: x86_64-pc-windows-gnu

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,7 +42,7 @@ install:
 test_script:
   # we don't run the "test phase" when doing deploys
   - if [%APPVEYOR_REPO_TAG%]==[false] (
-      cargo fmt --all -- --check
+      cargo fmt --all -- --check &&
       cargo build --target %TARGET% &&
       cargo build --target %TARGET% --release &&
       cargo test --target %TARGET% &&


### PR DESCRIPTION
AppVeyor script was using `stable` by default. There's some changes that prevent building. See for example this failure: https://ci.appveyor.com/project/nbigaouette/pycors/builds/21702948