### PR TITLE
Don't run the shim if file `.python-version` is absent

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,6 +1,6 @@
 use failure::format_err;
 
-use crate::{config::Cfg, settings::Settings, shim, Result};
+use crate::{config::Cfg, settings::Settings, shim, utils, Result};
 
 pub fn run(cfg: &Option<Cfg>, settings: &Settings, command_and_args: &str) -> Result<()> {
     let s = shlex::split(&command_and_args)
@@ -10,5 +10,7 @@ pub fn run(cfg: &Option<Cfg>, settings: &Settings, command_and_args: &str) -> Re
         .get(0)
         .ok_or_else(|| format_err!("Failed to extract command from {:?}", command_and_args))?;
 
-    shim::run(cfg, settings, cmd, arguments)
+    let interpreter_to_use = utils::get_interpreter_to_use(cfg, settings)?;
+
+    shim::run(&interpreter_to_use, cmd, arguments)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,5 +100,18 @@ pub fn python_shim(
     settings: &Settings,
     arguments: &[String],
 ) -> Result<()> {
-    shim::run(cfg, settings, command, arguments)
+    if cfg.is_some() {
+        shim::run(cfg, settings, command, arguments)
+    } else {
+        log::error!("No '.python-version' found.");
+        log::error!("Please select a Python version to use with:");
+        log::error!("    pycors use");
+        log::error!("");
+        log::error!("See available versions with:");
+        log::error!("    pycors list");
+
+        Err(format_err!(
+            "No .python-version file found. Select one with `pycors use`"
+        ))
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,18 +100,14 @@ pub fn python_shim(
     settings: &Settings,
     arguments: &[String],
 ) -> Result<()> {
-    if cfg.is_some() {
-        shim::run(cfg, settings, command, arguments)
-    } else {
-        log::error!("No '.python-version' found.");
-        log::error!("Please select a Python version to use with:");
-        log::error!("    pycors use");
-        log::error!("");
-        log::error!("See available versions with:");
-        log::error!("    pycors list");
-
-        Err(format_err!(
-            "No .python-version file found. Select one with `pycors use`"
-        ))
+    if !cfg.is_some() {
+        log::warn!("No '.python-version' found.");
+        log::warn!("Please select a Python version to use with:");
+        log::warn!("    pycors use");
+        log::warn!("");
+        log::warn!("See available versions with:");
+        log::warn!("    pycors list");
     }
+
+    shim::run(cfg, settings, command, arguments)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,12 @@ struct Opt {
 fn main() -> Result<()> {
     setup_panic!();
 
+    std::env::var("RUST_LOG").or_else(|_| -> Result<String> {
+        let rust_log = "pycors=warn".to_string();
+        std::env::set_var("RUST_LOG", &rust_log);
+        Ok(rust_log)
+    })?;
+
     env_logger::init();
 
     let settings = Settings::from_pycors_home()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,14 +106,7 @@ pub fn python_shim(
     settings: &Settings,
     arguments: &[String],
 ) -> Result<()> {
-    if !cfg.is_some() {
-        log::warn!("No '.python-version' found.");
-        log::warn!("Please select a Python version to use with:");
-        log::warn!("    pycors use");
-        log::warn!("");
-        log::warn!("See available versions with:");
-        log::warn!("    pycors list");
-    }
+    let interpreter_to_use = utils::get_interpreter_to_use(cfg, settings)?;
 
-    shim::run(cfg, settings, command, arguments)
+    shim::run(&interpreter_to_use, command, arguments)
 }

--- a/src/shim.rs
+++ b/src/shim.rs
@@ -1,5 +1,4 @@
 use failure::format_err;
-use shlex;
 use subprocess::{Exec, Redirection};
 
 use crate::{settings::PythonVersion, Result};

--- a/src/shim.rs
+++ b/src/shim.rs
@@ -2,14 +2,12 @@ use failure::format_err;
 use shlex;
 use subprocess::{Exec, Redirection};
 
-use crate::{config::Cfg, settings::Settings, utils, Result};
+use crate::{settings::PythonVersion, Result};
 
-pub fn run<S>(cfg: &Option<Cfg>, settings: &Settings, command: &str, arguments: &[S]) -> Result<()>
+pub fn run<S>(interpreter_to_use: &PythonVersion, command: &str, arguments: &[S]) -> Result<()>
 where
     S: AsRef<str> + std::convert::AsRef<std::ffi::OsStr> + std::fmt::Debug,
 {
-    let interpreter_to_use = utils::get_interpreter_to_use(cfg, settings)?;
-
     log::debug!("interpreter_to_use: {:?}", interpreter_to_use);
 
     // NOTE: Make sure the command given by the user contains the major Python version

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -137,6 +137,15 @@ pub fn active_version<'a>(
 }
 
 pub fn get_interpreter_to_use(cfg: &Option<Cfg>, settings: &Settings) -> Result<PythonVersion> {
+    if !cfg.is_some() {
+        log::warn!("No '.python-version' found.");
+        log::warn!("Please select a Python version to use with:");
+        log::warn!("    pycors use");
+        log::warn!("");
+        log::warn!("See available versions with:");
+        log::warn!("    pycors list");
+    }
+
     // If `cfg` is `None`, check if there is something in `Settings`; pick the first found
     // interpreter to construct a `cfg`.
     let cfg: Cfg = cfg

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -144,6 +144,8 @@ pub fn get_interpreter_to_use(cfg: &Option<Cfg>, settings: &Settings) -> Result<
         log::warn!("");
         log::warn!("See available versions with:");
         log::warn!("    pycors list");
+        log::warn!("");
+        log::warn!("pycors will select the highest version available.");
     }
 
     // If `cfg` is `None`, check if there is something in `Settings`; pick the first found


### PR DESCRIPTION
~Previously, if no `.python-version` file was present running the shim would pick up the most recent version installed.

The PR prevents this.~

A warning is printed when `.python-version` is not set:
```
 -> python -V
[2019-01-21T01:53:03Z WARN  pycors::utils] No '.python-version' found.
[2019-01-21T01:53:03Z WARN  pycors::utils] Please select a Python version to use with:
[2019-01-21T01:53:03Z WARN  pycors::utils]     pycors use
[2019-01-21T01:53:03Z WARN  pycors::utils]
[2019-01-21T01:53:03Z WARN  pycors::utils] See available versions with:
[2019-01-21T01:53:03Z WARN  pycors::utils]     pycors list
[2019-01-21T01:53:03Z WARN  pycors::utils]
[2019-01-21T01:53:03Z WARN  pycors::utils] pycors will select the highest version available.
Python 3.7.1
```

Closes #20.