### PR TITLE
Cleanup 'pycors' usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 name = "pycors"
 version = "0.1.14"
 authors = ["Nicolas Bigaouette <nbigaouette@gmail.com>"]
+homepage = "https://github.com/nbigaouette/pycors"
+repository = "https://github.com/nbigaouette/pycors"
 edition = "2018"
 
 [dependencies]

--- a/src/commands/autocomplete.rs
+++ b/src/commands/autocomplete.rs
@@ -1,8 +1,13 @@
+use std::io::Write;
+
 use structopt::{clap::Shell, StructOpt};
 
-use crate::{Opt, Result};
+use crate::{Opt, Result, EXECUTABLE_NAME};
 
-pub fn run(shell: Shell) -> Result<()> {
-    Opt::clap().gen_completions_to("pycors", shell, &mut std::io::stdout());
+pub fn run<W>(shell: Shell, buf: &mut W) -> Result<()>
+where
+    W: Write,
+{
+    Opt::clap().gen_completions_to(EXECUTABLE_NAME, shell, buf);
     Ok(())
 }

--- a/src/commands/install/download.rs
+++ b/src/commands/install/download.rs
@@ -95,7 +95,7 @@ pub fn download_from_url<P: AsRef<Path>>(url: &Url, download_to: P) -> Result<()
 
 pub fn download_source(version: &Version) -> Result<()> {
     let url = build_url(&version)?;
-    let download_dir = utils::directories::download()?;
+    let download_dir = utils::directories::downloaded()?;
     download_from_url(&url, download_dir)
 }
 

--- a/src/commands/install/download.rs
+++ b/src/commands/install/download.rs
@@ -95,7 +95,7 @@ pub fn download_from_url<P: AsRef<Path>>(url: &Url, download_to: P) -> Result<()
 
 pub fn download_source(version: &Version) -> Result<()> {
     let url = build_url(&version)?;
-    let download_dir = utils::directories::downloaded()?;
+    let download_dir = utils::directory::downloaded()?;
     download_from_url(&url, download_dir)
 }
 

--- a/src/commands/install/download.rs
+++ b/src/commands/install/download.rs
@@ -95,7 +95,7 @@ pub fn download_from_url<P: AsRef<Path>>(url: &Url, download_to: P) -> Result<()
 
 pub fn download_source(version: &Version) -> Result<()> {
     let url = build_url(&version)?;
-    let download_dir = utils::pycors_download()?;
+    let download_dir = utils::directories::download()?;
     download_from_url(&url, download_dir)
 }
 

--- a/src/commands/install/pip.rs
+++ b/src/commands/install/pip.rs
@@ -85,7 +85,7 @@ where
             log::debug!("pip: {:?}", pip);
             if let Some(pip) = pip.to_str() {
                 let basename = utils::build_basename(&version)?;
-                let extract_dir = utils::directories::extracted()?.join(&basename);
+                let extract_dir = utils::directory::extracted()?.join(&basename);
 
                 for (i, to_pip_install) in to_pip_installs.iter().enumerate() {
                     if let Err(e) = utils::run_cmd_template(
@@ -113,7 +113,7 @@ where
         let new_bin_files: Vec<_> = bin_dir_monitor.check()?.collect();
 
         // Create a hard-link for the new bins
-        let shim_dir = utils::directories::shims()?;
+        let shim_dir = utils::directory::shims()?;
         let executable_path = shim_dir.join(EXECUTABLE_NAME);
         for new_bin_file_path in new_bin_files {
             match new_bin_file_path.file_name() {

--- a/src/commands/install/pip.rs
+++ b/src/commands/install/pip.rs
@@ -85,7 +85,7 @@ where
             log::debug!("pip: {:?}", pip);
             if let Some(pip) = pip.to_str() {
                 let basename = utils::build_basename(&version)?;
-                let extract_dir = utils::directories::extract()?.join(&basename);
+                let extract_dir = utils::directories::extracted()?.join(&basename);
 
                 for (i, to_pip_install) in to_pip_installs.iter().enumerate() {
                     if let Err(e) = utils::run_cmd_template(

--- a/src/commands/install/pip.rs
+++ b/src/commands/install/pip.rs
@@ -85,7 +85,7 @@ where
             log::debug!("pip: {:?}", pip);
             if let Some(pip) = pip.to_str() {
                 let basename = utils::build_basename(&version)?;
-                let extract_dir = utils::pycors_extract()?.join(&basename);
+                let extract_dir = utils::directories::extract()?.join(&basename);
 
                 for (i, to_pip_install) in to_pip_installs.iter().enumerate() {
                     if let Err(e) = utils::run_cmd_template(
@@ -113,7 +113,7 @@ where
         let new_bin_files: Vec<_> = bin_dir_monitor.check()?.collect();
 
         // Create a hard-link for the new bins
-        let shim_dir = utils::pycors_shims()?;
+        let shim_dir = utils::directories::shims()?;
         let executable_path = shim_dir.join(EXECUTABLE_NAME);
         for new_bin_file_path in new_bin_files {
             match new_bin_file_path.file_name() {

--- a/src/commands/install/unix.rs
+++ b/src/commands/install/unix.rs
@@ -31,7 +31,7 @@ pub fn extract_source(version: &Version) -> Result<()> {
     let download_dir = utils::directories::download()?;
     let filename = build_filename(&version)?;
     let file_path = download_dir.join(&filename);
-    let extract_dir = utils::directories::extract()?;
+    let extract_dir = utils::directories::extracted()?;
 
     let line_header = "[2/15] Extract";
 
@@ -101,7 +101,7 @@ pub fn compile_source(
     }
 
     let basename = utils::build_basename(&version)?;
-    let extract_dir = utils::directories::extract()?.join(&basename);
+    let extract_dir = utils::directories::extracted()?.join(&basename);
 
     utils::run_cmd_template(
         &version,

--- a/src/commands/install/unix.rs
+++ b/src/commands/install/unix.rs
@@ -28,10 +28,10 @@ pub fn install_package(
 }
 
 pub fn extract_source(version: &Version) -> Result<()> {
-    let download_dir = utils::directories::downloaded()?;
+    let download_dir = utils::directory::downloaded()?;
     let filename = build_filename(&version)?;
     let file_path = download_dir.join(&filename);
-    let extract_dir = utils::directories::extracted()?;
+    let extract_dir = utils::directory::extracted()?;
 
     let line_header = "[2/15] Extract";
 
@@ -65,7 +65,7 @@ pub fn compile_source(
 
     let original_current_dir = env::current_dir()?;
 
-    let install_dir = utils::directories::install_dir(version)?;
+    let install_dir = utils::directory::install_dir(version)?;
 
     #[allow(unused_mut)]
     let mut configure_args = vec![
@@ -101,7 +101,7 @@ pub fn compile_source(
     }
 
     let basename = utils::build_basename(&version)?;
-    let extract_dir = utils::directories::extracted()?.join(&basename);
+    let extract_dir = utils::directory::extracted()?.join(&basename);
 
     utils::run_cmd_template(
         &version,

--- a/src/commands/install/unix.rs
+++ b/src/commands/install/unix.rs
@@ -28,7 +28,7 @@ pub fn install_package(
 }
 
 pub fn extract_source(version: &Version) -> Result<()> {
-    let download_dir = utils::directories::download()?;
+    let download_dir = utils::directories::downloaded()?;
     let filename = build_filename(&version)?;
     let file_path = download_dir.join(&filename);
     let extract_dir = utils::directories::extracted()?;

--- a/src/commands/install/unix.rs
+++ b/src/commands/install/unix.rs
@@ -28,10 +28,10 @@ pub fn install_package(
 }
 
 pub fn extract_source(version: &Version) -> Result<()> {
-    let download_dir = utils::pycors_download()?;
+    let download_dir = utils::directories::download()?;
     let filename = build_filename(&version)?;
     let file_path = download_dir.join(&filename);
-    let extract_dir = utils::pycors_extract()?;
+    let extract_dir = utils::directories::extract()?;
 
     let line_header = "[2/15] Extract";
 
@@ -65,7 +65,7 @@ pub fn compile_source(
 
     let original_current_dir = env::current_dir()?;
 
-    let install_dir = utils::install_dir(version)?;
+    let install_dir = utils::directories::install_dir(version)?;
 
     #[allow(unused_mut)]
     let mut configure_args = vec![
@@ -101,7 +101,7 @@ pub fn compile_source(
     }
 
     let basename = utils::build_basename(&version)?;
-    let extract_dir = utils::pycors_extract()?.join(&basename);
+    let extract_dir = utils::directories::extract()?.join(&basename);
 
     utils::run_cmd_template(
         &version,

--- a/src/commands/install/windows.rs
+++ b/src/commands/install/windows.rs
@@ -29,7 +29,7 @@ pub fn install_package(
         "Include_pip=1",
     ];
 
-    let cwd = utils::directories::download()?;
+    let cwd = utils::directories::downloaded()?;
     let exe = format!("./{}", build_filename_exe(version)?);
 
     utils::run_cmd_template(

--- a/src/commands/install/windows.rs
+++ b/src/commands/install/windows.rs
@@ -16,7 +16,7 @@ pub fn install_package(
 
     let original_current_dir = env::current_dir()?;
 
-    let install_dir = utils::install_dir(version)?;
+    let install_dir = utils::directories::install_dir(version)?;
     let target_dir_opt = format!("TargetDir={}", install_dir.display());
 
     let unattended_arguments = vec![
@@ -29,7 +29,7 @@ pub fn install_package(
         "Include_pip=1",
     ];
 
-    let cwd = utils::pycors_download()?;
+    let cwd = utils::directories::download()?;
     let exe = format!("./{}", build_filename_exe(version)?);
 
     utils::run_cmd_template(

--- a/src/commands/install/windows.rs
+++ b/src/commands/install/windows.rs
@@ -16,7 +16,7 @@ pub fn install_package(
 
     let original_current_dir = env::current_dir()?;
 
-    let install_dir = utils::directories::install_dir(version)?;
+    let install_dir = utils::directory::install_dir(version)?;
     let target_dir_opt = format!("TargetDir={}", install_dir.display());
 
     let unattended_arguments = vec![
@@ -29,7 +29,7 @@ pub fn install_package(
         "Include_pip=1",
     ];
 
-    let cwd = utils::directories::downloaded()?;
+    let cwd = utils::directory::downloaded()?;
     let exe = format!("./{}", build_filename_exe(version)?);
 
     utils::run_cmd_template(

--- a/src/commands/select.rs
+++ b/src/commands/select.rs
@@ -33,7 +33,7 @@ pub fn run(
                     false, // Don't 'select' here, will do so as last step.
                 )?
                 .ok_or_else(|| format_err!("A Python version should have been installed"))?;
-                let install_dir = utils::directories::install_dir(&version)?;
+                let install_dir = utils::directory::install_dir(&version)?;
 
                 PythonVersion {
                     version,

--- a/src/commands/select.rs
+++ b/src/commands/select.rs
@@ -33,7 +33,7 @@ pub fn run(
                     false, // Don't 'select' here, will do so as last step.
                 )?
                 .ok_or_else(|| format_err!("A Python version should have been installed"))?;
-                let install_dir = utils::install_dir(&version)?;
+                let install_dir = utils::directories::install_dir(&version)?;
 
                 PythonVersion {
                     version,

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -12,7 +12,7 @@ use crate::{commands, utils, Result, EXECUTABLE_NAME, EXTRA_PACKAGES_FILENAME_CO
 pub fn run(shell: Shell) -> Result<()> {
     log::debug!("Setting up the shim...");
 
-    // Copy itself into ~/.pycors/shim
+    // Copy itself into ~/.EXECUTABLE_NAME/shim
     let config_home_dir = utils::directory::config_home()?;
     let shims_dir = utils::directory::shims()?;
     if !utils::path_exists(&shims_dir) {
@@ -40,11 +40,11 @@ pub fn run(shell: Shell) -> Result<()> {
     ];
     let hardlinks_dash_version_suffix = &["2to3###", "easy_install###", "pyvenv###"];
 
-    // Create simple hardlinks: `pycors` --> `bin`
+    // Create simple hardlinks: `EXECUTABLE_NAME` --> `bin`
     utils::create_hard_links(&copy_from, hardlinks_version_suffix, &shims_dir, "")?;
     utils::create_hard_links(&copy_from, hardlinks_dash_version_suffix, &shims_dir, "")?;
 
-    // Create major version hardlinks: `pycors` --> `bin3` and `pycors` --> `bin2`
+    // Create major version hardlinks: `EXECUTABLE_NAME` --> `bin3` and `EXECUTABLE_NAME` --> `bin2`
     for major in &["2", "3"] {
         utils::create_hard_links(&copy_from, hardlinks_version_suffix, &shims_dir, major)?;
         utils::create_hard_links(
@@ -73,7 +73,7 @@ pub fn run(shell: Shell) -> Result<()> {
     let mut file = File::create(output_filename)?;
     file.write_all(extra_packages_file_default_content.as_bytes())?;
 
-    // Add ~/.pycors/bin to $PATH in ~/.bash_profile and install autocomplete
+    // Add ~/.EXECUTABLE_NAME/bin to $PATH in ~/.bash_profile and install autocomplete
     match shell {
         structopt::clap::Shell::Bash => {
             let home =

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -13,7 +13,7 @@ pub fn run(shell: Shell) -> Result<()> {
     log::debug!("Setting up the shim...");
 
     // Copy itself into ~/.pycors/shim
-    let pycors_home_dir = utils::pycors_home()?;
+    let pycors_home_dir = utils::config_home()?;
     let shims_dir = utils::pycors_shims()?;
     if !utils::path_exists(&shims_dir) {
         log::debug!("Directory {:?} does not exists, creating.", shims_dir);

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -5,9 +5,9 @@ use std::{
 };
 
 use failure::format_err;
-use structopt::{clap::Shell, StructOpt};
+use structopt::clap::Shell;
 
-use crate::{commands, utils, Opt, Result, EXECUTABLE_NAME, EXTRA_PACKAGES_FILENAME_CONTENT};
+use crate::{commands, utils, Result, EXECUTABLE_NAME, EXTRA_PACKAGES_FILENAME_CONTENT};
 
 pub fn run(shell: Shell) -> Result<()> {
     log::debug!("Setting up the shim...");

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -7,7 +7,7 @@ use std::{
 use failure::format_err;
 use structopt::{clap::Shell, StructOpt};
 
-use crate::{utils, Opt, Result, EXECUTABLE_NAME};
+use crate::{utils, Opt, Result, EXECUTABLE_NAME, EXTRA_PACKAGES_FILENAME_REL};
 
 pub fn run(shell: Shell) -> Result<()> {
     log::debug!("Setting up the shim...");
@@ -61,7 +61,7 @@ pub fn run(shell: Shell) -> Result<()> {
     let mut file = fs::File::create(&pycors_dummy_file)?;
     writeln!(file, "This file's job is to tell pycors the directory contains shim, not real Python interpreters.")?;
 
-    let extra_packages_file_default_content = include_str!("../../extra-packages-to-install.txt");
+    let extra_packages_file_default_content = include_str!(EXTRA_PACKAGES_FILENAME_REL);
     let output_filename = utils::default_extra_package_file()?;
     log::debug!(
         "Writing list of default packages to install to {:?}",

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -57,7 +57,7 @@ pub fn run(shell: Shell) -> Result<()> {
 
     // Create an dummy file that will be recognized when searching the PATH for
     // python interpreters. We don't want to "find" the shims we install here.
-    let pycors_dummy_file = shims_dir.join("pycors_dummy_file");
+    let pycors_dummy_file = utils::file::install_dummy_file()?;
     let mut file = fs::File::create(&pycors_dummy_file)?;
     writeln!(file, "This file's job is to tell pycors the directory contains shim, not real Python interpreters.")?;
 

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -7,7 +7,7 @@ use std::{
 use failure::format_err;
 use structopt::{clap::Shell, StructOpt};
 
-use crate::{utils, Opt, Result, EXECUTABLE_NAME, EXTRA_PACKAGES_FILENAME_CONTENT};
+use crate::{commands, utils, Opt, Result, EXECUTABLE_NAME, EXTRA_PACKAGES_FILENAME_CONTENT};
 
 pub fn run(shell: Shell) -> Result<()> {
     log::debug!("Setting up the shim...");
@@ -84,7 +84,7 @@ pub fn run(shell: Shell) -> Result<()> {
             let autocomplete_file =
                 config_home_dir.join(&format!("{}.bash-completion", EXECUTABLE_NAME));
             let mut f = fs::File::create(&autocomplete_file)?;
-            Opt::clap().gen_completions_to(EXECUTABLE_NAME, shell, &mut f);
+            commands::autocomplete::run(shell, &mut f)?;
 
             log::debug!("Adding {:?} to $PATH in {:?}...", shims_dir, bash_profile);
             let bash_profile_line = format!(r#"export PATH="{}:$PATH""#, shims_dir.display());

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -55,15 +55,6 @@ pub fn run(shell: Shell) -> Result<()> {
         )?;
     }
 
-    // Create an dummy file that will be recognized when searching the PATH for
-    // python interpreters. We don't want to "find" the shims we install here.
-    let mut file = fs::File::create(utils::file::install_dummy_file()?)?;
-    writeln!(
-        file,
-        "This file's job is to tell {} the directory contains shim, not real Python interpreters.",
-        EXECUTABLE_NAME
-    )?;
-
     let extra_packages_file_default_content = EXTRA_PACKAGES_FILENAME_CONTENT;
     let output_filename = utils::default_extra_package_file()?;
     log::debug!(

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -128,7 +128,7 @@ pub fn run(shell: Shell) -> Result<()> {
                     String::from(""),
                     "#################################################".to_string(),
                     format!("# These lines were added by {}.", EXECUTABLE_NAME),
-                    "# See https://github.com/nbigaouette/pycors".to_string(),
+                    format!("# See {}", env!("CARGO_PKG_HOMEPAGE")),
                     if !bash_profile_existed {
                         "source ${HOME}/.bashrc".to_string()
                     } else {

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -7,7 +7,7 @@ use std::{
 use failure::format_err;
 use structopt::{clap::Shell, StructOpt};
 
-use crate::{utils, Opt, Result, EXECUTABLE_NAME, EXTRA_PACKAGES_FILENAME_REL};
+use crate::{utils, Opt, Result, EXECUTABLE_NAME, EXTRA_PACKAGES_FILENAME_CONTENT};
 
 pub fn run(shell: Shell) -> Result<()> {
     log::debug!("Setting up the shim...");
@@ -61,7 +61,7 @@ pub fn run(shell: Shell) -> Result<()> {
     let mut file = fs::File::create(&pycors_dummy_file)?;
     writeln!(file, "This file's job is to tell pycors the directory contains shim, not real Python interpreters.")?;
 
-    let extra_packages_file_default_content = include_str!(EXTRA_PACKAGES_FILENAME_REL);
+    let extra_packages_file_default_content = EXTRA_PACKAGES_FILENAME_CONTENT;
     let output_filename = utils::default_extra_package_file()?;
     log::debug!(
         "Writing list of default packages to install to {:?}",

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -13,8 +13,8 @@ pub fn run(shell: Shell) -> Result<()> {
     log::debug!("Setting up the shim...");
 
     // Copy itself into ~/.pycors/shim
-    let pycors_home_dir = utils::directories::config_home()?;
-    let shims_dir = utils::directories::shims()?;
+    let pycors_home_dir = utils::directory::config_home()?;
+    let shims_dir = utils::directory::shims()?;
     if !utils::path_exists(&shims_dir) {
         log::debug!("Directory {:?} does not exists, creating.", shims_dir);
         fs::create_dir_all(&shims_dir)?;

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -13,8 +13,8 @@ pub fn run(shell: Shell) -> Result<()> {
     log::debug!("Setting up the shim...");
 
     // Copy itself into ~/.pycors/shim
-    let pycors_home_dir = utils::config_home()?;
-    let shims_dir = utils::pycors_shims()?;
+    let pycors_home_dir = utils::directories::config_home()?;
+    let shims_dir = utils::directories::shims()?;
     if !utils::path_exists(&shims_dir) {
         log::debug!("Directory {:?} does not exists, creating.", shims_dir);
         fs::create_dir_all(&shims_dir)?;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -21,8 +21,11 @@ pub fn home_env_variable() -> &'static str {
     &HOME_ENV_VARIABLE
 }
 
+/// Filename describing which version of this project installed a toolchain.
 pub const INFO_FILE: &str = concat!("installed_by_", executable_name_from_env!(), ".txt");
 
+/// Filename containing the list of extra packages to install using `pip`.
 pub const EXTRA_PACKAGES_FILENAME: &str = "extra-packages-to-install.txt";
 
+/// Content of file listing extra `pip` packages to install, copied when setting-up shim.
 pub const EXTRA_PACKAGES_FILENAME_CONTENT: &str = include_str!("../extra-packages-to-install.txt");

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,16 @@
+/// Name of the executable, reused across project.
+pub const EXECUTABLE_NAME: &str = env!("CARGO_PKG_NAME");
+
+/// Default hidden configuration directory.
+pub const DEFAULT_DOT_DIR: String = format!(".{}", EXECUTABLE_NAME);
+
+///
+pub const HOME_ENV_VARIABLE: String = format!("{}_HOME", EXECUTABLE_NAME.to_uppercase());
+
+pub const INFO_FILE: String = format!("installed_by_{}.txt", EXECUTABLE_NAME);
+
+pub const EXTRA_PACKAGES_FILENAME: &str = "extra-packages-to-install.txt";
+
+pub const EXTRA_PACKAGES_FILENAME_CONTENT: &str = include_str!("../extra-packages-to-install.txt");
+
+pub const INSTALL_DUMMY_FILE: &str = "installed_dummy_file";

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,13 +1,27 @@
+use lazy_static::lazy_static;
+
+macro_rules! executable_name_from_env {
+    () => {
+        env!("CARGO_PKG_NAME")
+    };
+}
+
 /// Name of the executable, reused across project.
-pub const EXECUTABLE_NAME: &str = env!("CARGO_PKG_NAME");
+pub const EXECUTABLE_NAME: &str = executable_name_from_env!();
 
 /// Default hidden configuration directory.
-pub const DEFAULT_DOT_DIR: String = format!(".{}", EXECUTABLE_NAME);
+pub const DEFAULT_DOT_DIR: &str = concat!(".", executable_name_from_env!());
 
-///
-pub const HOME_ENV_VARIABLE: String = format!("{}_HOME", EXECUTABLE_NAME.to_uppercase());
+/// Return the environment variable used to find the project's config home.
+pub fn home_env_variable() -> &'static str {
+    lazy_static! {
+        static ref HOME_ENV_VARIABLE: String =
+            format!("{}_HOME", executable_name_from_env!().to_uppercase());
+    }
+    &HOME_ENV_VARIABLE
+}
 
-pub const INFO_FILE: String = format!("installed_by_{}.txt", EXECUTABLE_NAME);
+pub const INFO_FILE: &str = concat!("installed_by_", executable_name_from_env!(), ".txt");
 
 pub const EXTRA_PACKAGES_FILENAME: &str = "extra-packages-to-install.txt";
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -26,5 +26,3 @@ pub const INFO_FILE: &str = concat!("installed_by_", executable_name_from_env!()
 pub const EXTRA_PACKAGES_FILENAME: &str = "extra-packages-to-install.txt";
 
 pub const EXTRA_PACKAGES_FILENAME_CONTENT: &str = include_str!("../extra-packages-to-install.txt");
-
-pub const INSTALL_DUMMY_FILE: &str = "installed_dummy_file";

--- a/src/dir_monitor.rs
+++ b/src/dir_monitor.rs
@@ -34,6 +34,7 @@ impl DirectoryMonitor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::EXECUTABLE_NAME;
     use std::{
         env,
         fs::{create_dir_all, remove_dir_all, File},
@@ -48,7 +49,9 @@ mod tests {
 
     #[test]
     fn one_file() {
-        let tmp_dir = env::temp_dir().join("pycors_tests").join("one_file");
+        let tmp_dir = env::temp_dir()
+            .join(&format!("{}_tests", EXECUTABLE_NAME))
+            .join("one_file");
         let _ = remove_dir_all(&tmp_dir);
         create_dir_all(&tmp_dir).unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use structopt::StructOpt;
 
 mod commands;
 mod config;
+mod constants;
 mod dir_monitor;
 mod os;
 mod settings;
@@ -18,18 +19,11 @@ mod utils;
 use crate::{
     commands::Command,
     config::{load_config_file, Cfg},
+    constants::*,
     settings::Settings,
 };
 
 pub type Result<T> = std::result::Result<T, failure::Error>;
-
-pub const EXECUTABLE_NAME: &str = "pycors";
-pub const DEFAULT_DOT_DIR: &str = ".pycors";
-pub const HOME_VARIABLE: &str = "PYCORS_HOME";
-pub const INFO_FILE: &str = "installed_by.txt";
-pub const EXTRA_PACKAGES_FILENAME: &str = "extra-packages-to-install.txt";
-pub const EXTRA_PACKAGES_FILENAME_CONTENT: &str = include_str!("../extra-packages-to-install.txt");
-pub const INSTALL_DUMMY_FILE: &str = "installed_dummy_file";
 
 git_testament!(GIT_TESTAMENT);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ pub const DEFAULT_DOT_DIR: &str = ".pycors";
 pub const HOME_VARIABLE: &str = "PYCORS_HOME";
 pub const INFO_FILE: &str = "installed_by.txt";
 pub const EXTRA_PACKAGES_FILENAME: &str = "extra-packages-to-install.txt";
-pub const EXTRA_PACKAGES_FILENAME_REL: &str = "../../extra-packages-to-install.txt";
+pub const EXTRA_PACKAGES_FILENAME_CONTENT: &str = include_str!("../extra-packages-to-install.txt");
 
 git_testament!(GIT_TESTAMENT);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ fn main() -> Result<()> {
 
     env_logger::init();
 
-    let settings = Settings::from_pycors_home()?;
+    let settings = Settings::from_dot_dir()?;
     // Invert the Option<Result> to Result<Option> and use ? to unwrap the Result.
     let cfg_opt = load_config_file().map_or(Ok(None), |v| v.map(Some))?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,8 @@ pub const EXECUTABLE_NAME: &str = "pycors";
 pub const DEFAULT_DOT_DIR: &str = ".pycors";
 pub const HOME_VARIABLE: &str = "PYCORS_HOME";
 pub const INFO_FILE: &str = "installed_by.txt";
+pub const EXTRA_PACKAGES_FILENAME: &str = "extra-packages-to-install.txt";
+pub const EXTRA_PACKAGES_FILENAME_REL: &str = "../../extra-packages-to-install.txt";
 
 git_testament!(GIT_TESTAMENT);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ use crate::{
 pub type Result<T> = std::result::Result<T, failure::Error>;
 
 pub const EXECUTABLE_NAME: &str = "pycors";
+pub const DEFAULT_DOT_DIR: &str = ".pycors";
 pub const HOME_VARIABLE: &str = "PYCORS_HOME";
 pub const INFO_FILE: &str = "installed_by.txt";
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ pub const HOME_VARIABLE: &str = "PYCORS_HOME";
 pub const INFO_FILE: &str = "installed_by.txt";
 pub const EXTRA_PACKAGES_FILENAME: &str = "extra-packages-to-install.txt";
 pub const EXTRA_PACKAGES_FILENAME_CONTENT: &str = include_str!("../extra-packages-to-install.txt");
+pub const INSTALL_DUMMY_FILE: &str = "installed_dummy_file";
 
 git_testament!(GIT_TESTAMENT);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ use crate::{
 pub type Result<T> = std::result::Result<T, failure::Error>;
 
 pub const EXECUTABLE_NAME: &str = "pycors";
+pub const HOME_VARIABLE: &str = "PYCORS_HOME";
 pub const INFO_FILE: &str = "installed_by.txt";
 
 git_testament!(GIT_TESTAMENT);

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ fn main() -> Result<()> {
     setup_panic!();
 
     std::env::var("RUST_LOG").or_else(|_| -> Result<String> {
-        let rust_log = "pycors=warn".to_string();
+        let rust_log = format!("{}=warn", EXECUTABLE_NAME);
         std::env::set_var("RUST_LOG", &rust_log);
         Ok(rust_log)
     })?;
@@ -84,9 +84,9 @@ fn main() -> Result<()> {
                 }
             };
 
-            if exe.starts_with("pycors") {
-                debug!("Running pycors");
                 pycors(&cfg_opt, &settings)?;
+            if exe.starts_with(EXECUTABLE_NAME) {
+                debug!("Running {}", EXECUTABLE_NAME);
             } else {
                 debug!("Running a Python shim");
                 python_shim(exe, &cfg_opt, &settings, remaining_args)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,7 @@ pub fn pycors(cfg: &Option<Cfg>, settings: &Settings) -> Result<()> {
     if let Some(subcommand) = opt.subcommand {
         match subcommand {
             Command::Autocomplete { shell } => {
-                commands::autocomplete::run(shell)?;
+                commands::autocomplete::run(shell, &mut std::io::stdout())?;
             }
             Command::List => commands::list::run(cfg, settings)?,
             Command::Path => commands::path::run(cfg, settings)?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,9 +84,9 @@ fn main() -> Result<()> {
                 }
             };
 
-                pycors(&cfg_opt, &settings)?;
             if exe.starts_with(EXECUTABLE_NAME) {
                 debug!("Running {}", EXECUTABLE_NAME);
+                no_shim_execution(&cfg_opt, &settings)?;
             } else {
                 debug!("Running a Python shim");
                 python_shim(exe, &cfg_opt, &settings, remaining_args)?;
@@ -97,7 +97,7 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-pub fn pycors(cfg: &Option<Cfg>, settings: &Settings) -> Result<()> {
+pub fn no_shim_execution(cfg: &Option<Cfg>, settings: &Settings) -> Result<()> {
     let opt = Opt::from_args();
     log::debug!("{:?}", opt);
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -9,7 +9,7 @@ use semver::Version;
 use subprocess::{Exec, Redirection};
 use which::which_in;
 
-use crate::{utils, Result, EXECUTABLE_NAME, INSTALL_DUMMY_FILE};
+use crate::{utils, Result, EXECUTABLE_NAME};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct PythonVersion {
@@ -162,7 +162,7 @@ where
             let python_pathbuf: PathBuf = python_path.to_path_buf();
 
             log::debug!("python_path: {}", python_path.display());
-            if python_path.join(INSTALL_DUMMY_FILE).exists() {
+            if python_path.join(EXECUTABLE_NAME).exists() {
                 log::debug!("Skipping {}' shim directory.", EXECUTABLE_NAME);
                 break;
             }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -9,7 +9,7 @@ use semver::Version;
 use subprocess::{Exec, Redirection};
 use which::which_in;
 
-use crate::{utils, Result};
+use crate::{utils, Result, EXECUTABLE_NAME, INSTALL_DUMMY_FILE};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct PythonVersion {
@@ -162,8 +162,8 @@ where
             let python_pathbuf: PathBuf = python_path.to_path_buf();
 
             log::debug!("python_path: {}", python_path.display());
-            if python_path.join("pycors_dummy_file").exists() {
-                log::debug!("Skipping pycors' shim directory.");
+            if python_path.join(INSTALL_DUMMY_FILE).exists() {
+                log::debug!("Skipping {}' shim directory.", EXECUTABLE_NAME);
                 break;
             }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -38,7 +38,7 @@ pub struct Settings {
 }
 
 impl Settings {
-    pub fn from_pycors_home() -> Result<Settings> {
+    pub fn from_dot_dir() -> Result<Settings> {
         let install_dir = utils::directory::installed()?;
 
         let mut installed_python = Vec::new();

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -39,7 +39,7 @@ pub struct Settings {
 
 impl Settings {
     pub fn from_pycors_home() -> Result<Settings> {
-        let install_dir = utils::pycors_installed()?;
+        let install_dir = utils::directories::installed()?;
 
         let mut installed_python = Vec::new();
         log::debug!("install_dir: {}", install_dir.display());
@@ -104,7 +104,7 @@ impl Settings {
             }
         };
 
-        let pycors_home_dir = utils::config_home()?;
+        let pycors_home_dir = utils::directories::config_home()?;
         let bin_dir = pycors_home_dir.join("bin");
 
         // Find other Python installed (f.e. in system directories)

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -39,7 +39,7 @@ pub struct Settings {
 
 impl Settings {
     pub fn from_pycors_home() -> Result<Settings> {
-        let install_dir = utils::directories::installed()?;
+        let install_dir = utils::directory::installed()?;
 
         let mut installed_python = Vec::new();
         log::debug!("install_dir: {}", install_dir.display());
@@ -104,7 +104,7 @@ impl Settings {
             }
         };
 
-        let pycors_home_dir = utils::directories::config_home()?;
+        let pycors_home_dir = utils::directory::config_home()?;
         let bin_dir = pycors_home_dir.join("bin");
 
         // Find other Python installed (f.e. in system directories)

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -104,7 +104,7 @@ impl Settings {
             }
         };
 
-        let pycors_home_dir = utils::pycors_home()?;
+        let pycors_home_dir = utils::config_home()?;
         let bin_dir = pycors_home_dir.join("bin");
 
         // Find other Python installed (f.e. in system directories)

--- a/src/shim.rs
+++ b/src/shim.rs
@@ -55,7 +55,7 @@ where
     let new_bin_files: Vec<_> = bin_dir_monitor.check()?.collect();
 
     // Create a hard-link for the new bins
-    let shim_dir = utils::directories::shims()?;
+    let shim_dir = utils::directory::shims()?;
     let executable_path = shim_dir.join(EXECUTABLE_NAME);
     for new_bin_file_path in new_bin_files {
         match new_bin_file_path.file_name() {

--- a/src/shim.rs
+++ b/src/shim.rs
@@ -55,7 +55,7 @@ where
     let new_bin_files: Vec<_> = bin_dir_monitor.check()?.collect();
 
     // Create a hard-link for the new bins
-    let shim_dir = utils::pycors_shims()?;
+    let shim_dir = utils::directories::shims()?;
     let executable_path = shim_dir.join(EXECUTABLE_NAME);
     for new_bin_file_path in new_bin_files {
         match new_bin_file_path.file_name() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -42,16 +42,16 @@ pub fn copy_file<P1: AsRef<Path>, P2: AsRef<Path>>(from: P1, to: P2) -> Result<u
 pub fn config_home() -> Result<PathBuf> {
     let env_var = env::var_os(HOME_VARIABLE);
 
-    let pycors_home = if env_var.is_some() {
+    let config_home_from_env = if env_var.is_some() {
         let cwd = env::current_dir()?;
         env_var.clone().map(|home| cwd.join(home))
     } else {
         None
     };
 
-    let user_home = dot_dir(DEFAULT_DOT_DIR);
+    let default_dot_dir = dot_dir(DEFAULT_DOT_DIR);
 
-    let home = match pycors_home.or(user_home) {
+    let home = match config_home_from_env.or(default_dot_dir) {
         None => Err(format_err!("Cannot find pycors' home directory")),
         Some(home) => Ok(home),
     }?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -480,15 +480,15 @@ mod tests {
     }
 
     #[test]
-    fn pycors_home_default() {
-        env::remove_var("PYCORS_HOME");
+    fn home_default() {
+        env::remove_var(HOME_VARIABLE);
         let default_home = directory::config_home().unwrap();
         let expected = home_dir().unwrap().join(".pycors");
         assert_eq!(default_home, expected);
     }
 
     #[test]
-    fn pycors_home_from_env_variable() {
+    fn home_from_env_variable() {
         let tmp_dir = env::temp_dir();
         env::set_var("PYCORS_HOME", &tmp_dir);
         let tmp_home = directory::config_home().unwrap();
@@ -497,15 +497,15 @@ mod tests {
 
     #[test]
     fn dot_dir_success() {
-        env::remove_var("PYCORS_HOME");
+        env::remove_var(HOME_VARIABLE);
         let dir = directory::dot_dir(".dummy").unwrap();
         let expected = home_dir().unwrap().join(".dummy");
         assert_eq!(dir, expected);
     }
 
     #[test]
-    fn pycors_directories() {
-        env::remove_var("PYCORS_HOME");
+    fn directories() {
+        env::remove_var(HOME_VARIABLE);
         let dir = directory::cache().unwrap();
         let expected = home_dir().unwrap().join(".pycors").join("cache");
         assert_eq!(dir, expected);
@@ -533,7 +533,7 @@ mod tests {
 
     #[test]
     fn install_dir_version() {
-        env::remove_var("PYCORS_HOME");
+        env::remove_var(HOME_VARIABLE);
         let version = Version::parse("3.7.2").unwrap();
         let dir = directory::install_dir(&version).unwrap();
         let expected = home_dir()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,7 +19,7 @@ use terminal_size::{terminal_size, Width};
 use crate::{
     config::Cfg,
     settings::{PythonVersion, Settings},
-    Result, DEFAULT_DOT_DIR, EXECUTABLE_NAME, HOME_VARIABLE,
+    Result, DEFAULT_DOT_DIR, EXECUTABLE_NAME, EXTRA_PACKAGES_FILENAME, HOME_VARIABLE,
 };
 
 pub fn path_exists<P: AsRef<Path>>(path: P) -> bool {
@@ -99,7 +99,7 @@ pub mod directory {
 }
 
 pub fn default_extra_package_file() -> Result<PathBuf> {
-    Ok(directory::config_home()?.join("extra-packages-to-install.txt"))
+    Ok(directory::config_home()?.join(EXTRA_PACKAGES_FILENAME))
 }
 
 pub fn build_basename(version: &Version) -> Result<String> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -490,7 +490,7 @@ mod tests {
     #[test]
     fn home_from_env_variable() {
         let tmp_dir = env::temp_dir();
-        env::set_var("PYCORS_HOME", &tmp_dir);
+        env::set_var(HOME_VARIABLE, &tmp_dir);
         let tmp_home = directory::config_home().unwrap();
         assert_eq!(tmp_home, Path::new(&tmp_dir));
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,7 +19,7 @@ use terminal_size::{terminal_size, Width};
 use crate::{
     config::Cfg,
     settings::{PythonVersion, Settings},
-    Result, DEFAULT_DOT_DIR, HOME_VARIABLE,
+    Result, DEFAULT_DOT_DIR, EXECUTABLE_NAME, HOME_VARIABLE,
 };
 
 pub fn path_exists<P: AsRef<Path>>(path: P) -> bool {
@@ -52,7 +52,10 @@ pub fn config_home() -> Result<PathBuf> {
     let default_dot_dir = dot_dir(DEFAULT_DOT_DIR);
 
     let home = match config_home_from_env.or(default_dot_dir) {
-        None => Err(format_err!("Cannot find pycors' home directory")),
+        None => Err(format_err!(
+            "Cannot find {}' home directory",
+            EXECUTABLE_NAME
+        )),
         Some(home) => Ok(home),
     }?;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -483,7 +483,7 @@ mod tests {
     fn home_default() {
         env::remove_var(HOME_VARIABLE);
         let default_home = directory::config_home().unwrap();
-        let expected = home_dir().unwrap().join(".pycors");
+        let expected = home_dir().unwrap().join(DEFAULT_DOT_DIR);
         assert_eq!(default_home, expected);
     }
 
@@ -507,13 +507,13 @@ mod tests {
     fn directories() {
         env::remove_var(HOME_VARIABLE);
         let dir = directory::cache().unwrap();
-        let expected = home_dir().unwrap().join(".pycors").join("cache");
+        let expected = home_dir().unwrap().join(DEFAULT_DOT_DIR).join("cache");
         assert_eq!(dir, expected);
 
         let dir = directory::downloaded().unwrap();
         let expected = home_dir()
             .unwrap()
-            .join(".pycors")
+            .join(DEFAULT_DOT_DIR)
             .join("cache")
             .join("downloaded");
         assert_eq!(dir, expected);
@@ -521,13 +521,13 @@ mod tests {
         let dir = directory::extracted().unwrap();
         let expected = home_dir()
             .unwrap()
-            .join(".pycors")
+            .join(DEFAULT_DOT_DIR)
             .join("cache")
             .join("extracted");
         assert_eq!(dir, expected);
 
         let dir = directory::installed().unwrap();
-        let expected = home_dir().unwrap().join(".pycors").join("installed");
+        let expected = home_dir().unwrap().join(DEFAULT_DOT_DIR).join("installed");
         assert_eq!(dir, expected);
     }
 
@@ -538,7 +538,7 @@ mod tests {
         let dir = directory::install_dir(&version).unwrap();
         let expected = home_dir()
             .unwrap()
-            .join(".pycors")
+            .join(DEFAULT_DOT_DIR)
             .join("installed")
             .join("3.7.2");
         assert_eq!(dir, expected);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -18,8 +18,9 @@ use terminal_size::{terminal_size, Width};
 
 use crate::{
     config::Cfg,
+    constants::{home_env_variable, DEFAULT_DOT_DIR, EXECUTABLE_NAME, EXTRA_PACKAGES_FILENAME},
     settings::{PythonVersion, Settings},
-    Result, DEFAULT_DOT_DIR, EXECUTABLE_NAME, EXTRA_PACKAGES_FILENAME, HOME_ENV_VARIABLE,
+    Result,
 };
 
 pub fn path_exists<P: AsRef<Path>>(path: P) -> bool {
@@ -47,7 +48,7 @@ pub mod directory {
     }
 
     pub fn config_home() -> Result<PathBuf> {
-        let env_var = env::var_os(HOME_ENV_VARIABLE);
+        let env_var = env::var_os(home_env_variable());
 
         let config_home_from_env = if env_var.is_some() {
             let cwd = env::current_dir()?;
@@ -56,7 +57,7 @@ pub mod directory {
             None
         };
 
-        let default_dot_dir = dot_dir(DEFAULT_DOT_DIR);
+        let default_dot_dir = dot_dir(&DEFAULT_DOT_DIR);
 
         let home = match config_home_from_env.or(default_dot_dir) {
             None => Err(format_err!(
@@ -490,7 +491,7 @@ mod tests {
 
     #[test]
     fn home_default() {
-        env::remove_var(HOME_VARIABLE);
+        env::remove_var(home_env_variable());
         let default_home = directory::config_home().unwrap();
         let expected = home_dir().unwrap().join(DEFAULT_DOT_DIR);
         assert_eq!(default_home, expected);
@@ -499,14 +500,14 @@ mod tests {
     #[test]
     fn home_from_env_variable() {
         let tmp_dir = env::temp_dir();
-        env::set_var(HOME_VARIABLE, &tmp_dir);
+        env::set_var(home_env_variable(), &tmp_dir);
         let tmp_home = directory::config_home().unwrap();
         assert_eq!(tmp_home, Path::new(&tmp_dir));
     }
 
     #[test]
     fn dot_dir_success() {
-        env::remove_var(HOME_VARIABLE);
+        env::remove_var(home_env_variable());
         let dir = directory::dot_dir(".dummy").unwrap();
         let expected = home_dir().unwrap().join(".dummy");
         assert_eq!(dir, expected);
@@ -514,7 +515,7 @@ mod tests {
 
     #[test]
     fn directories() {
-        env::remove_var(HOME_VARIABLE);
+        env::remove_var(home_env_variable());
         let dir = directory::cache().unwrap();
         let expected = home_dir().unwrap().join(DEFAULT_DOT_DIR).join("cache");
         assert_eq!(dir, expected);
@@ -542,7 +543,7 @@ mod tests {
 
     #[test]
     fn install_dir_version() {
-        env::remove_var(HOME_VARIABLE);
+        env::remove_var(home_env_variable());
         let version = Version::parse("3.7.2").unwrap();
         let dir = directory::install_dir(&version).unwrap();
         let expected = home_dir()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -39,7 +39,7 @@ pub fn copy_file<P1: AsRef<Path>, P2: AsRef<Path>>(from: P1, to: P2) -> Result<u
     }
 }
 
-pub fn pycors_home() -> Result<PathBuf> {
+pub fn config_home() -> Result<PathBuf> {
     let env_var = env::var_os("PYCORS_HOME");
 
     let pycors_home = if env_var.is_some() {
@@ -64,7 +64,7 @@ fn dot_dir(name: &str) -> Option<PathBuf> {
 }
 
 pub fn pycors_cache() -> Result<PathBuf> {
-    Ok(pycors_home()?.join("cache"))
+    Ok(config_home()?.join("cache"))
 }
 
 pub fn pycors_download() -> Result<PathBuf> {
@@ -76,15 +76,15 @@ pub fn pycors_extract() -> Result<PathBuf> {
 }
 
 pub fn pycors_installed() -> Result<PathBuf> {
-    Ok(pycors_home()?.join("installed"))
+    Ok(config_home()?.join("installed"))
 }
 
 pub fn pycors_shims() -> Result<PathBuf> {
-    Ok(pycors_home()?.join("shims"))
+    Ok(config_home()?.join("shims"))
 }
 
 pub fn pycors_logs() -> Result<PathBuf> {
-    Ok(pycors_home()?.join("logs"))
+    Ok(config_home()?.join("logs"))
 }
 
 pub fn install_dir(version: &Version) -> Result<PathBuf> {
@@ -92,7 +92,7 @@ pub fn install_dir(version: &Version) -> Result<PathBuf> {
 }
 
 pub fn default_extra_package_file() -> Result<PathBuf> {
-    Ok(pycors_home()?.join("extra-packages-to-install.txt"))
+    Ok(config_home()?.join("extra-packages-to-install.txt"))
 }
 
 pub fn build_basename(version: &Version) -> Result<String> {
@@ -469,7 +469,7 @@ mod tests {
     #[test]
     fn pycors_home_default() {
         env::remove_var("PYCORS_HOME");
-        let default_home = pycors_home().unwrap();
+        let default_home = config_home().unwrap();
         let expected = home_dir().unwrap().join(".pycors");
         assert_eq!(default_home, expected);
     }
@@ -478,7 +478,7 @@ mod tests {
     fn pycors_home_from_env_variable() {
         let tmp_dir = env::temp_dir();
         env::set_var("PYCORS_HOME", &tmp_dir);
-        let tmp_home = pycors_home().unwrap();
+        let tmp_home = config_home().unwrap();
         assert_eq!(tmp_home, Path::new(&tmp_dir));
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -39,7 +39,7 @@ pub fn copy_file<P1: AsRef<Path>, P2: AsRef<Path>>(from: P1, to: P2) -> Result<u
     }
 }
 
-pub mod directories {
+pub mod directory {
     use super::*;
 
     pub fn dot_dir(name: &str) -> Option<PathBuf> {
@@ -99,7 +99,7 @@ pub mod directories {
 }
 
 pub fn default_extra_package_file() -> Result<PathBuf> {
-    Ok(directories::config_home()?.join("extra-packages-to-install.txt"))
+    Ok(directory::config_home()?.join("extra-packages-to-install.txt"))
 }
 
 pub fn build_basename(version: &Version) -> Result<String> {
@@ -294,7 +294,7 @@ where
     S: AsRef<std::ffi::OsStr> + std::fmt::Debug,
     P: AsRef<Path>,
 {
-    let logs_dir = directories::logs()?;
+    let logs_dir = directory::logs()?;
 
     if !logs_dir.exists() {
         fs::create_dir_all(&logs_dir)?;
@@ -476,7 +476,7 @@ mod tests {
     #[test]
     fn pycors_home_default() {
         env::remove_var("PYCORS_HOME");
-        let default_home = directories::config_home().unwrap();
+        let default_home = directory::config_home().unwrap();
         let expected = home_dir().unwrap().join(".pycors");
         assert_eq!(default_home, expected);
     }
@@ -485,14 +485,14 @@ mod tests {
     fn pycors_home_from_env_variable() {
         let tmp_dir = env::temp_dir();
         env::set_var("PYCORS_HOME", &tmp_dir);
-        let tmp_home = directories::config_home().unwrap();
+        let tmp_home = directory::config_home().unwrap();
         assert_eq!(tmp_home, Path::new(&tmp_dir));
     }
 
     #[test]
     fn dot_dir_success() {
         env::remove_var("PYCORS_HOME");
-        let dir = directories::dot_dir(".dummy").unwrap();
+        let dir = directory::dot_dir(".dummy").unwrap();
         let expected = home_dir().unwrap().join(".dummy");
         assert_eq!(dir, expected);
     }
@@ -500,11 +500,11 @@ mod tests {
     #[test]
     fn pycors_directories() {
         env::remove_var("PYCORS_HOME");
-        let dir = directories::cache().unwrap();
+        let dir = directory::cache().unwrap();
         let expected = home_dir().unwrap().join(".pycors").join("cache");
         assert_eq!(dir, expected);
 
-        let dir = directories::downloaded().unwrap();
+        let dir = directory::downloaded().unwrap();
         let expected = home_dir()
             .unwrap()
             .join(".pycors")
@@ -512,7 +512,7 @@ mod tests {
             .join("downloaded");
         assert_eq!(dir, expected);
 
-        let dir = directories::extracted().unwrap();
+        let dir = directory::extracted().unwrap();
         let expected = home_dir()
             .unwrap()
             .join(".pycors")
@@ -520,7 +520,7 @@ mod tests {
             .join("extracted");
         assert_eq!(dir, expected);
 
-        let dir = directories::installed().unwrap();
+        let dir = directory::installed().unwrap();
         let expected = home_dir().unwrap().join(".pycors").join("installed");
         assert_eq!(dir, expected);
     }
@@ -529,7 +529,7 @@ mod tests {
     fn install_dir_version() {
         env::remove_var("PYCORS_HOME");
         let version = Version::parse("3.7.2").unwrap();
-        let dir = directories::install_dir(&version).unwrap();
+        let dir = directory::install_dir(&version).unwrap();
         let expected = home_dir()
             .unwrap()
             .join(".pycors")

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -77,7 +77,7 @@ pub mod directories {
         Ok(cache()?.join("downloads"))
     }
 
-    pub fn extract() -> Result<PathBuf> {
+    pub fn extracted() -> Result<PathBuf> {
         Ok(cache()?.join("extracted"))
     }
 
@@ -512,7 +512,7 @@ mod tests {
             .join("downloads");
         assert_eq!(dir, expected);
 
-        let dir = directories::extract().unwrap();
+        let dir = directories::extracted().unwrap();
         let expected = home_dir()
             .unwrap()
             .join(".pycors")

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -74,7 +74,7 @@ pub mod directories {
     }
 
     pub fn download() -> Result<PathBuf> {
-        Ok(cache()?.join("downloads"))
+        Ok(cache()?.join("downloaded"))
     }
 
     pub fn extracted() -> Result<PathBuf> {
@@ -509,7 +509,7 @@ mod tests {
             .unwrap()
             .join(".pycors")
             .join("cache")
-            .join("downloads");
+            .join("downloaded");
         assert_eq!(dir, expected);
 
         let dir = directories::extracted().unwrap();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -196,12 +196,15 @@ pub fn get_interpreter_to_use(cfg: &Option<Cfg>, settings: &Settings) -> Result<
     if !cfg.is_some() {
         log::warn!("No '.python-version' found.");
         log::warn!("Please select a Python version to use with:");
-        log::warn!("    pycors select <version>");
+        log::warn!("    {} select <version>", EXECUTABLE_NAME);
         log::warn!("");
         log::warn!("See available versions with:");
-        log::warn!("    pycors list");
+        log::warn!("    {} list", EXECUTABLE_NAME);
         log::warn!("");
-        log::warn!("pycors will select the highest version available.");
+        log::warn!(
+            "{} will select the highest version available.",
+            EXECUTABLE_NAME
+        );
     }
 
     // If `cfg` is `None`, check if there is something in `Settings`; pick the first found
@@ -222,7 +225,10 @@ pub fn get_interpreter_to_use(cfg: &Option<Cfg>, settings: &Settings) -> Result<
             }
         })
         .ok_or_else(|| {
-            format_err!("No Python runtime configured. Use `pycors select <version> <version>`.")
+            format_err!(
+                "No Python runtime configured. Use `{} select <version> <version>`.",
+                EXECUTABLE_NAME
+            )
         })?;
 
     let active_python = active_version(&cfg.version, settings).ok_or_else(|| {
@@ -234,9 +240,9 @@ pub fn get_interpreter_to_use(cfg: &Option<Cfg>, settings: &Settings) -> Result<
         log::error!("    1) Remove the file `.python-version` to use (one of) the interpreter(s) available in your $PATH.");
         log::error!("    2) Edit the file to use an installed interpreter.");
         log::error!("       For example, to list available interpreters:");
-        log::error!("           pycors list");
+        log::error!("           {} list", EXECUTABLE_NAME);
         log::error!("       Then select a version to use:");
-        log::error!("           pycors select <version> ~3.7");
+        log::error!("           {} select <version> ~3.7", EXECUTABLE_NAME);
         format_err!("No active Python runtime found.")
     })?.clone();
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -73,7 +73,7 @@ pub mod directories {
         Ok(config_home()?.join("cache"))
     }
 
-    pub fn download() -> Result<PathBuf> {
+    pub fn downloaded() -> Result<PathBuf> {
         Ok(cache()?.join("downloaded"))
     }
 
@@ -504,7 +504,7 @@ mod tests {
         let expected = home_dir().unwrap().join(".pycors").join("cache");
         assert_eq!(dir, expected);
 
-        let dir = directories::download().unwrap();
+        let dir = directories::downloaded().unwrap();
         let expected = home_dir()
             .unwrap()
             .join(".pycors")

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,7 +19,7 @@ use terminal_size::{terminal_size, Width};
 use crate::{
     config::Cfg,
     settings::{PythonVersion, Settings},
-    Result, DEFAULT_DOT_DIR, EXECUTABLE_NAME, EXTRA_PACKAGES_FILENAME, HOME_VARIABLE,
+    Result, DEFAULT_DOT_DIR, EXECUTABLE_NAME, EXTRA_PACKAGES_FILENAME, HOME_ENV_VARIABLE,
 };
 
 pub fn path_exists<P: AsRef<Path>>(path: P) -> bool {
@@ -47,7 +47,7 @@ pub mod directory {
     }
 
     pub fn config_home() -> Result<PathBuf> {
-        let env_var = env::var_os(HOME_VARIABLE);
+        let env_var = env::var_os(HOME_ENV_VARIABLE);
 
         let config_home_from_env = if env_var.is_some() {
             let cwd = env::current_dir()?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,7 +19,7 @@ use terminal_size::{terminal_size, Width};
 use crate::{
     config::Cfg,
     settings::{PythonVersion, Settings},
-    Result,
+    Result, HOME_VARIABLE,
 };
 
 pub fn path_exists<P: AsRef<Path>>(path: P) -> bool {
@@ -40,7 +40,7 @@ pub fn copy_file<P1: AsRef<Path>, P2: AsRef<Path>>(from: P1, to: P2) -> Result<u
 }
 
 pub fn config_home() -> Result<PathBuf> {
-    let env_var = env::var_os("PYCORS_HOME");
+    let env_var = env::var_os(HOME_VARIABLE);
 
     let pycors_home = if env_var.is_some() {
         let cwd = env::current_dir()?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -98,6 +98,15 @@ pub mod directory {
     }
 }
 
+pub mod file {
+    use super::*;
+    use crate::INSTALL_DUMMY_FILE;
+
+    pub fn install_dummy_file() -> Result<PathBuf> {
+        Ok(directory::shims()?.join(INSTALL_DUMMY_FILE))
+    }
+}
+
 pub fn default_extra_package_file() -> Result<PathBuf> {
     Ok(directory::config_home()?.join(EXTRA_PACKAGES_FILENAME))
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -99,15 +99,6 @@ pub mod directory {
     }
 }
 
-pub mod file {
-    use super::*;
-    use crate::INSTALL_DUMMY_FILE;
-
-    pub fn install_dummy_file() -> Result<PathBuf> {
-        Ok(directory::shims()?.join(INSTALL_DUMMY_FILE))
-    }
-}
-
 pub fn default_extra_package_file() -> Result<PathBuf> {
     Ok(directory::config_home()?.join(EXTRA_PACKAGES_FILENAME))
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,7 +19,7 @@ use terminal_size::{terminal_size, Width};
 use crate::{
     config::Cfg,
     settings::{PythonVersion, Settings},
-    Result, HOME_VARIABLE,
+    Result, DEFAULT_DOT_DIR, HOME_VARIABLE,
 };
 
 pub fn path_exists<P: AsRef<Path>>(path: P) -> bool {
@@ -49,7 +49,7 @@ pub fn config_home() -> Result<PathBuf> {
         None
     };
 
-    let user_home = dot_dir(".pycors");
+    let user_home = dot_dir(DEFAULT_DOT_DIR);
 
     let home = match pycors_home.or(user_home) {
         None => Err(format_err!("Cannot find pycors' home directory")),


### PR DESCRIPTION
This PR gets rid of (almost) all usage of `pycors` in the code.

Everything derives from the package name, set in Cargo.toml and obtained via `env!("CARGO_PKG_NAME")`.

This is a first step towards #40.