### PR TITLE
Convert 'failure' error handling to 'anyhow'+'thiserror'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,11 +930,11 @@ dependencies = [
 name = "pycors"
 version = "0.2.1"
 dependencies = [
+ "anyhow 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "console 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "git-testament 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "human-panic 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -953,6 +953,7 @@ dependencies = [
  "subprocess 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "terminal_size 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "which 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1457,6 +1458,24 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thiserror-impl 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2111,6 +2130,8 @@ dependencies = [
 "checksum terminal_size 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "023345d35850b69849741bd9a5432aa35290e3d8eb76af8717026f270d1cf133"
 "checksum termios 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "72b620c5ea021d75a735c943269bb07d30c9b77d6ac6b236bc8b5c496ef05625"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+"checksum thiserror 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "cc6b305ec0e323c7b6cfff6098a22516e0063d0bb7c3d88660a890217dca099a"
+"checksum thiserror-impl 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45ba8d810d9c48fc456b7ad54574e8bfb7c7918a57ad7a6e6a0985d7959e8597"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ console = "0.9"
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "2"
 env_logger = "0.7"
-failure = "0.1"
+anyhow = "1.0"
 flate2 = "1.0"
 git-testament = "0.1"
 human-panic = "1.0"
@@ -31,6 +31,7 @@ serde = {version = "1", features =[ "derive"]}
 serde_json = "1"
 structopt = "0.3"
 subprocess = "0.1"
+thiserror = "1.0"
 tar = "0.4"
 terminal_size = "0.1"
 url = { version = "2", features = ["serde"] }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -4,16 +4,18 @@ use std::{
     path::PathBuf,
 };
 
+use anyhow::Result;
 use chrono::{DateTime, Utc};
 use regex::Regex;
 use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 use serde_json;
+use thiserror::Error;
 use url::Url;
 
 use crate::{
     constants::{AVAILABLE_TOOLCHAIN_CACHE, PYTHON_BASE_URL},
-    utils, Result,
+    utils,
 };
 
 // FIXME: Pre-releases are available inside 'https://www.python.org/ftp/python/MAJOR.MINOR.PATCH'
@@ -23,9 +25,9 @@ use crate::{
 
 // FIXME: Use https://www.python.org/downloads/source/ instead to get all links of releases!
 
-#[derive(Debug, failure::Fail)]
+#[derive(Debug, Error)]
 pub enum CacheError {
-    #[fail(display = "No compatible version found")]
+    #[error("No compatible version found")]
     NoCompatibleVersionFound,
 }
 

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -4,15 +4,15 @@ use std::{
     path::PathBuf,
 };
 
-use failure::format_err;
+use anyhow::{anyhow, Result};
 use semver::{Version, VersionReq};
+use thiserror::Error;
 
 use crate::{
     cache::AvailableToolchainsCache,
     commands::{self, install::download::download_source},
     constants::{EXECUTABLE_NAME, TOOLCHAIN_FILE},
     toolchain::{find_installed_toolchains, installed::InstalledToolchain, ToolchainFile},
-    Result,
 };
 
 mod download;
@@ -20,12 +20,9 @@ mod pip;
 mod unix;
 mod windows;
 
-#[derive(Debug, failure::Fail)]
+#[derive(Debug, Error)]
 pub enum InstallError {
-    #[fail(
-        display = "Cannot install toolchain from file when specified as path ({:?})",
-        _0
-    )]
+    #[error("Cannot install toolchain from file when specified as path ({0:?})")]
     ToolchainFileContainsPath(PathBuf),
 }
 
@@ -168,7 +165,7 @@ fn selected_version_from_user_input() -> Result<VersionReq> {
     let stdin = io::stdin();
     println!("Please type the Python version to use in this directory:");
     let line = match stdin.lock().lines().next() {
-        None => return Err(format_err!("Standard input did not contain a single line")),
+        None => return Err(anyhow!("Standard input did not contain a single line")),
         Some(line_result) => line_result?,
     };
     log::debug!("Given: {}", line);
@@ -177,7 +174,7 @@ fn selected_version_from_user_input() -> Result<VersionReq> {
 
     if line.is_empty() {
         log::error!("Empty line given as input.");
-        Err(format_err!("Empty line provided"))
+        Err(anyhow!("Empty line provided"))
     } else {
         log::debug!("Parsed version: {}", version);
         Ok(version)

--- a/src/commands/install/download.rs
+++ b/src/commands/install/download.rs
@@ -4,12 +4,12 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use failure::format_err;
+use anyhow::{anyhow, Result};
 use indicatif::{ProgressBar, ProgressStyle};
 use semver::Version;
 use url::Url;
 
-use crate::{os::build_filename, utils, Result};
+use crate::{os::build_filename, utils};
 
 pub fn download_from_url<P: AsRef<Path>>(url: &Url, download_to: P) -> Result<()> {
     let line_header = "[1/15] Download";
@@ -23,9 +23,9 @@ pub fn download_from_url<P: AsRef<Path>>(url: &Url, download_to: P) -> Result<()
 
     let filename = url
         .path_segments()
-        .ok_or_else(|| format_err!("Could not extract filename from url"))?
+        .ok_or_else(|| anyhow!("Could not extract filename from url"))?
         .last()
-        .ok_or_else(|| format_err!("Could not get last segment from url path"))?
+        .ok_or_else(|| anyhow!("Could not get last segment from url path"))?
         .to_string();
 
     let mut file_path = PathBuf::new();
@@ -87,7 +87,7 @@ pub fn download_from_url<P: AsRef<Path>>(url: &Url, download_to: P) -> Result<()
             log::error!("Failed to download {}: {:?}", resp.url(), resp.status());
             let res = resp.error_for_status();
             res.map(|_| ())
-                .map_err(|e| format_err!("Failed to download file: {:?}", e))
+                .map_err(|e| anyhow!("Failed to download file: {:?}", e))
         }
     }
 }

--- a/src/commands/install/unix.rs
+++ b/src/commands/install/unix.rs
@@ -5,7 +5,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use failure::format_err;
+use anyhow::{anyhow, Result};
 use flate2::read::GzDecoder;
 use semver::Version;
 #[cfg(target_os = "macos")]
@@ -16,7 +16,6 @@ use crate::{
     commands::{self, install::pip::install_extra_pip_packages},
     os::build_filename,
     utils::{self, SpinnerMessage},
-    Result,
 };
 
 #[cfg_attr(windows, allow(dead_code))]
@@ -55,7 +54,7 @@ pub fn extract_source(version: &Version) -> Result<()> {
 
     child
         .join()
-        .map_err(|e| format_err!("Failed to join threads: {:?}", e))?;
+        .map_err(|e| anyhow!("Failed to join threads: {:?}", e))?;
 
     Ok(())
 }
@@ -76,7 +75,7 @@ pub fn compile_source(
         "--prefix".to_string(),
         install_dir
             .to_str()
-            .ok_or_else(|| format_err!("Error converting install dir {:?} to `str`", install_dir))?
+            .ok_or_else(|| anyhow!("Error converting install dir {:?} to `str`", install_dir))?
             .to_string(),
         "--enable-optimizations".to_string(),
     ];

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,20 +1,21 @@
-use failure::format_err;
+use anyhow::{anyhow, Result};
+use thiserror::Error;
 
-use crate::{shim, toolchain::CompatibleToolchainBuilder, Result};
+use crate::{shim, toolchain::CompatibleToolchainBuilder};
 
-#[derive(Debug, failure::Fail)]
+#[derive(Debug, Error)]
 pub enum RunError {
-    #[fail(display = "No interpreter found to run command: {}", _0)]
+    #[error("No interpreter found to run command: {0}")]
     MissingInterpreter(String),
 }
 
 pub fn run(version: Option<String>, command_and_args: &str) -> Result<()> {
     let s = shlex::split(&command_and_args)
-        .ok_or_else(|| format_err!("Failed to split command from {:?}", command_and_args))?;
+        .ok_or_else(|| anyhow!("Failed to split command from {:?}", command_and_args))?;
     let (cmd, arguments) = s.split_at(1);
     let cmd = cmd
         .get(0)
-        .ok_or_else(|| format_err!("Failed to extract command from {:?}", command_and_args))?;
+        .ok_or_else(|| anyhow!("Failed to extract command from {:?}", command_and_args))?;
 
     let compatible_toolchain_builder = match version {
         Some(version) => CompatibleToolchainBuilder::new().load_from_string(&version),

--- a/src/commands/select.rs
+++ b/src/commands/select.rs
@@ -1,11 +1,11 @@
-use failure::format_err;
+use anyhow::{anyhow, Result};
 
 use crate::{
     commands,
     toolchain::{
         find_installed_toolchains, installed::InstalledToolchain, selected::VersionOrPath,
     },
-    utils, Result,
+    utils,
 };
 
 pub fn run(requested_version_or_path: commands::VersionOrPath) -> Result<()> {
@@ -25,7 +25,7 @@ pub fn run(requested_version_or_path: commands::VersionOrPath) -> Result<()> {
                     python_to_use.clone()
                 }
                 None => {
-                    return Err(format_err!(
+                    return Err(anyhow!(
                         "Python version {} not found!",
                         requested_version_or_path.version_or_path
                     ));
@@ -39,7 +39,7 @@ pub fn run(requested_version_or_path: commands::VersionOrPath) -> Result<()> {
                 python_to_use
             }
             None => {
-                return Err(format_err!(
+                return Err(anyhow!(
                     "Could not find a Python interpreter under {:?}",
                     path
                 ));

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -4,10 +4,10 @@ use std::{
     io::{BufRead, BufReader, Write},
 };
 
-use failure::format_err;
+use anyhow::{anyhow, Result};
 use structopt::clap::Shell;
 
-use crate::{commands, utils, Result, EXECUTABLE_NAME, EXTRA_PACKAGES_FILENAME_CONTENT};
+use crate::{commands, utils, EXECUTABLE_NAME, EXTRA_PACKAGES_FILENAME_CONTENT};
 
 pub fn run(shell: Shell) -> Result<()> {
     log::debug!("Setting up the shim...");
@@ -67,8 +67,7 @@ pub fn run(shell: Shell) -> Result<()> {
     // Add ~/.EXECUTABLE_NAME/bin to $PATH in ~/.bashrc and install autocomplete
     match shell {
         structopt::clap::Shell::Bash => {
-            let home =
-                dirs::home_dir().ok_or_else(|| format_err!("Error getting home directory"))?;
+            let home = dirs::home_dir().ok_or_else(|| anyhow!("Error getting home directory"))?;
             let bashrc = home.join(".bashrc");
 
             // Add the autocomplete too
@@ -145,6 +144,6 @@ pub fn run(shell: Shell) -> Result<()> {
 
             Ok(())
         }
-        _ => Err(format_err!("Unsupported shell: {}", shell)),
+        _ => Err(anyhow!("Unsupported shell: {}", shell)),
     }
 }

--- a/src/os/unix.rs
+++ b/src/os/unix.rs
@@ -1,7 +1,7 @@
-use failure::format_err;
+use anyhow::{anyhow, Result};
 use semver::Version;
 
-use crate::{toolchain::installed::InstalledToolchain, utils, Result};
+use crate::{toolchain::installed::InstalledToolchain, utils};
 
 #[cfg_attr(windows, allow(dead_code))]
 pub fn build_filename_tgz(version: &Version) -> Result<String> {
@@ -22,7 +22,7 @@ pub fn command_with_major_version(
         command
             .chars()
             .last()
-            .ok_or_else(|| format_err!("Cannot get last character from command {:?}", command))?
+            .ok_or_else(|| anyhow!("Cannot get last character from command {:?}", command))?
     );
 
     let command_string_with_major_version = {

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -8,22 +8,24 @@ use std::{
     str::FromStr,
 };
 
+use anyhow::Result;
 use semver::{Version, VersionReq};
 use subprocess::{Exec, Redirection};
+use thiserror::Error;
 use which::which_in;
 
-use crate::{constants::TOOLCHAIN_FILE, utils, Result, EXECUTABLE_NAME};
+use crate::{constants::TOOLCHAIN_FILE, utils, EXECUTABLE_NAME};
 
 pub mod installed;
 pub mod selected;
 
 use installed::{InstalledToolchain, NotInstalledToolchain};
 
-#[derive(Debug, failure::Fail)]
+#[derive(Debug, Error)]
 pub enum ToolchainError {
-    #[fail(display = "Failed to get working current directory: {:?}", _0)]
-    FailedCurrentDir(#[fail(cause)] io::Error),
-    #[fail(display = "Toolchain file {:?} is empty", _0)]
+    #[error("Failed to get working current directory: {:?}", _0)]
+    FailedCurrentDir(#[from] io::Error),
+    #[error("Toolchain file {:?} is empty", _0)]
     EmptyToolchainFile(PathBuf),
 }
 

--- a/src/toolchain/installed.rs
+++ b/src/toolchain/installed.rs
@@ -4,12 +4,14 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use anyhow::Result;
 use semver::{Version, VersionReq};
+use thiserror::Error;
 
-use crate::{constants::TOOLCHAIN_FILE, toolchain::get_python_versions_from_path, Result};
+use crate::{constants::TOOLCHAIN_FILE, toolchain::get_python_versions_from_path};
 
-#[derive(Debug, Clone, failure::Fail)]
-#[fail(display = "Python version {} not found!", version)]
+#[derive(Debug, Clone, Error)]
+#[error("Python version {version} not found!")]
 pub struct ToolchainNotInstalled {
     version: VersionReq,
 }


### PR DESCRIPTION
Failure depends on `backtrace-sys`, which needs to compile a C library. On Windows that requires a C/C++ compiler, which is annoying.

`anyhow` [easily converts](https://github.com/dtolnay/anyhow#details) to `std::error::Error` using `?`.