### PR TITLE
Integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,11 +132,16 @@ jobs:
         with:
           name: pycors.exe
           path: target/debug/pycors.exe
-      - name: Test (cargo test)
+      - name: Unit Tests (cargo test)
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-fail-fast -- --nocapture
+          args: --no-fail-fast --bin pycors -- --nocapture
+      - name: Integration Tests (cargo test integration)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-fail-fast integration -- --nocapture
 
   clippy:
     name: Clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,12 +136,12 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-fail-fast --bin pycors -- --nocapture
+          args: --no-fail-fast "tests::" -- --nocapture
       - name: Integration Tests (cargo test integration)
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-fail-fast integration -- --nocapture
+          args: --no-fail-fast "integration::" -- --nocapture
 
   clippy:
     name: Clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,6 @@ jobs:
 
   coverage:
     name: Code coverage
-    needs: [fmt, check, test, clippy]
     runs-on: ubuntu-18.04
     container:
       image: xd009642/tarpaulin@sha256:5b9ad2082bd87f791528598fcbb9c94c920029ee464d6e688c9ab1bf78e4ab89
@@ -227,7 +226,7 @@ jobs:
   create_release:
     name: Create GitHub release
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    needs: coverage
+    needs: [fmt, check, test, clippy, coverage]
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,18 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "assert_cmd"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "doc-comment 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "escargot 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "predicates 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "predicates-tree 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,6 +305,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "doc-comment"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "downcast"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +329,17 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "escargot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -975,6 +1003,7 @@ name = "pycors"
 version = "0.2.2"
 dependencies = [
  "anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "assert_cmd 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -991,6 +1020,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockall 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "predicates 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "question 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1623,6 +1653,7 @@ dependencies = [
 "checksum anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9267dff192e68f3399525901e709a48c1d3982c9c072fa32f2127a0cb0babf14"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+"checksum assert_cmd 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6283bac8dd7226470d491bc4737816fea4ca1fba7a2847f2e9097fd6bfb4624c"
 "checksum async-trait 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "8b6dd385bb33043b833ba049048d57bdbb4d654a121ed68c71871ca51ff67070"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
@@ -1653,9 +1684,11 @@ dependencies = [
 "checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 "checksum dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 "checksum dirs-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
+"checksum doc-comment 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
 "checksum downcast 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
 "checksum encode_unicode 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 "checksum env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+"checksum escargot 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "74cf96bec282dcdb07099f7e31d9fed323bca9435a09aba7b6d99b7617bca96d"
 "checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
 "checksum failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
 "checksum filetime 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1ff6d4dab0aa0c8e6346d46052e93b13a16cf847b54ed357087c35011048cc7d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,6 +667,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "indoc-impl 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "indoc-impl"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unindent 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,6 +1037,7 @@ dependencies = [
  "hyper 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-tls 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indoc 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockall 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1514,6 +1536,11 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unindent"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "url"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1724,6 +1751,8 @@ dependencies = [
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d7b3ea5827fcb9d4fda14bf4da5f136f0db2ae9c8f4bd4e2d1c6fde4e6db2"
 "checksum indicatif 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8572bccfb0665e70b7faf44ee28841b8e0823450cd4ad562a76b5a3c4bf48487"
+"checksum indoc 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3f9553c1e16c114b8b77ebeb329e5f2876eed62a8d51178c8bc6bff0d65f98f8"
+"checksum indoc-impl 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b714fc08d0961716390977cdff1536234415ac37b509e34e5a983def8340fb75"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
@@ -1821,6 +1850,7 @@ dependencies = [
 "checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+"checksum unindent 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "63f18aa3b0e35fed5a0048f029558b1518095ffe2a0a31fb87c93dece93a4993"
 "checksum url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61"
 "checksum users 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c72f4267aea0c3ec6d07eaabea6ead7c5ddacfafc5e22bcf8d186706851fb4cf"
 "checksum vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,11 @@ zip = {version = "0.5", default-features = false, features = ["deflate"]}
 
 [dev-dependencies]
 mockall = "0.6"
+# pretty_assertions = "0.6"
 
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies.users]
 version = "0.9"
 default_features = false
-
-# pretty_assertions = "*"
 
 # On Linux (musl), use the openssl 'vendored' feature to build a static version of OpenSSL.
 # See:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,8 @@ zip = {version = "0.5", default-features = false, features = ["deflate"]}
 
 [dev-dependencies]
 mockall = "0.6"
+assert_cmd = "0.12"
+predicates = "1"
 # pretty_assertions = "0.6"
 
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies.users]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ zip = {version = "0.5", default-features = false, features = ["deflate"]}
 mockall = "0.6"
 assert_cmd = "0.12"
 predicates = "1"
+indoc = "0.3"
 # pretty_assertions = "0.6"
 
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies.users]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -227,27 +227,20 @@ fn parse_index_html(index_html: &str) -> Result<Vec<AvailableToolchain>> {
 
 #[cfg(test)]
 mod tests {
-    use std::{env, fs, path::PathBuf};
+    use std::fs;
 
     use chrono::Duration;
 
     use super::*;
-    use crate::utils::directory::MockPycorsHomeProviderTrait;
+    use crate::{tests::temp_dir, utils::directory::MockPycorsHomeProviderTrait};
 
     use mockall::predicate::*;
 
     const INDEX_HTML: &str = include_str!("../tests/fixtures/index.html");
 
-    fn temp_dir() -> PathBuf {
-        env::temp_dir()
-            .join(crate::constants::EXECUTABLE_NAME)
-            .join("cache")
-            .join("tests")
-    }
-
     #[test]
     fn cache_new_empty() {
-        let pycors_home = temp_dir().join("cache_from_env");
+        let pycors_home = temp_dir("cache", "cache_from_env");
         let home = pycors_home.clone();
 
         let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
@@ -276,7 +269,7 @@ mod tests {
 
     #[test]
     fn cache_up_to_date() {
-        let pycors_home = temp_dir().join("cache_up_to_date");
+        let pycors_home = temp_dir("cache", "cache_up_to_date");
         let home = pycors_home.clone();
 
         let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
@@ -328,7 +321,7 @@ mod tests {
 
     #[test]
     fn cache_corrupted() {
-        let pycors_home = temp_dir().join("cache_corrupted");
+        let pycors_home = temp_dir("cache", "cache_corrupted");
         let home = pycors_home.clone();
 
         let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
@@ -384,7 +377,7 @@ mod tests {
 
     #[test]
     fn cache_outdated() {
-        let pycors_home = temp_dir().join("cache_outdated");
+        let pycors_home = temp_dir("cache", "cache_outdated");
         let home = pycors_home.clone();
 
         let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -248,6 +248,8 @@ mod tests {
     #[test]
     fn cache_new_empty() {
         let pycors_home = temp_dir().join("cache_from_env");
+        let home = pycors_home.clone();
+
         let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
 
         // The test expects an empty directory
@@ -258,7 +260,10 @@ mod tests {
         let mut mock = MockPycorsHomeProviderTrait::new();
         mock.expect_home_env_variable()
             .times(3)
-            .return_const(mocked_pycors_home.clone());
+            .return_const(mocked_pycors_home);
+        mock.expect_home()
+            .times(3)
+            .returning(move || Ok(home.clone()));
 
         let paths_provider = PycorsPathsProvider::from(mock);
 
@@ -272,6 +277,8 @@ mod tests {
     #[test]
     fn cache_up_to_date() {
         let pycors_home = temp_dir().join("cache_up_to_date");
+        let home = pycors_home.clone();
+
         let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
 
         // The test expects an empty directory
@@ -281,8 +288,12 @@ mod tests {
 
         let mut mock = MockPycorsHomeProviderTrait::new();
         mock.expect_home_env_variable()
-            .times(2 + 1) // +1 since we later get the cache file
+            .times(1)
             .return_const(mocked_pycors_home.clone());
+        mock.expect_home()
+            .times(1)
+            .returning(move || Ok(home.clone()));
+
         let paths_provider = PycorsPathsProvider::from(mock);
         let cache_file = paths_provider.available_toolchains_cache_file();
 
@@ -297,6 +308,16 @@ mod tests {
         let mut f = File::create(cache_file).unwrap();
         f.write_all(cache_json.as_bytes()).unwrap();
 
+        let home = pycors_home;
+        let mut mock = MockPycorsHomeProviderTrait::new();
+        mock.expect_home_env_variable()
+            .times(2)
+            .return_const(mocked_pycors_home);
+        mock.expect_home()
+            .times(2)
+            .returning(move || Ok(home.clone()));
+        let paths_provider = PycorsPathsProvider::from(mock);
+
         // Let's create the cache for real
         let mut mock = MockToolchainsCacheFetch::new();
         mock.expect_get()
@@ -310,6 +331,8 @@ mod tests {
         crate::tests::init_logger();
 
         let pycors_home = temp_dir().join("cache_corrupted");
+        let home = pycors_home.clone();
+
         let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
 
         // The test expects an empty directory
@@ -319,8 +342,12 @@ mod tests {
 
         let mut mock = MockPycorsHomeProviderTrait::new();
         mock.expect_home_env_variable()
-            .times(3 + 1) // +1 since we later get the cache file
+            .times(1)
             .return_const(mocked_pycors_home.clone());
+        mock.expect_home()
+            .times(1)
+            .returning(move || Ok(home.clone()));
+
         let paths_provider = PycorsPathsProvider::from(mock);
         let cache_file = paths_provider.available_toolchains_cache_file();
 
@@ -339,6 +366,17 @@ mod tests {
             .unwrap();
 
         // Let's create the cache for real
+
+        let home = pycors_home;
+        let mut mock = MockPycorsHomeProviderTrait::new();
+        mock.expect_home_env_variable()
+            .times(3)
+            .return_const(mocked_pycors_home);
+        mock.expect_home()
+            .times(3)
+            .returning(move || Ok(home.clone()));
+        let paths_provider = PycorsPathsProvider::from(mock);
+
         let mut mock = MockToolchainsCacheFetch::new();
         mock.expect_get()
             .times(1) // Cache file is corrupted, new download required.
@@ -351,6 +389,8 @@ mod tests {
         crate::tests::init_logger();
 
         let pycors_home = temp_dir().join("cache_outdated");
+        let home = pycors_home.clone();
+
         let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
 
         // The test expects an empty directory
@@ -360,8 +400,12 @@ mod tests {
 
         let mut mock = MockPycorsHomeProviderTrait::new();
         mock.expect_home_env_variable()
-            .times(3 + 1) // +1 since we later get the cache file
+            .times(1)
             .return_const(mocked_pycors_home.clone());
+        mock.expect_home()
+            .times(1)
+            .returning(move || Ok(home.clone()));
+
         let paths_provider = PycorsPathsProvider::from(mock);
         let cache_file = paths_provider.available_toolchains_cache_file();
 
@@ -377,6 +421,16 @@ mod tests {
         let cache_bytes = cache_json.as_bytes();
         // Save the cache
         f.write_all(&cache_bytes).unwrap();
+
+        let home = pycors_home;
+        let mut mock = MockPycorsHomeProviderTrait::new();
+        mock.expect_home_env_variable()
+            .times(3)
+            .return_const(mocked_pycors_home);
+        mock.expect_home()
+            .times(3)
+            .returning(move || Ok(home.clone()));
+        let paths_provider = PycorsPathsProvider::from(mock);
 
         let mut mock = MockToolchainsCacheFetch::new();
         mock.expect_get()

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -328,8 +328,6 @@ mod tests {
 
     #[test]
     fn cache_corrupted() {
-        crate::tests::init_logger();
-
         let pycors_home = temp_dir().join("cache_corrupted");
         let home = pycors_home.clone();
 
@@ -386,8 +384,6 @@ mod tests {
 
     #[test]
     fn cache_outdated() {
-        crate::tests::init_logger();
-
         let pycors_home = temp_dir().join("cache_outdated");
         let home = pycors_home.clone();
 
@@ -441,8 +437,6 @@ mod tests {
 
     #[test]
     fn parse_html() {
-        crate::tests::init_logger();
-
         let parsed: Vec<AvailableToolchain> = parse_index_html(INDEX_HTML).unwrap();
         assert_eq!(parsed.len(), 213);
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -58,10 +58,10 @@ pub enum Command {
     /// Use `pycors install` for this.
     ///
     /// For example:
-    ///     pycors select 3.6
+    ///   pycors select 3.6
     /// will select ~3.6 (the most up to date version of the 3.6 series).
     ///
-    ///     pycors select =3.7.2
+    ///   pycors select =3.7.2
     /// will select an exact version.
     #[structopt(name = "select")]
     Select(VersionOrPath),

--- a/src/commands/autocomplete.rs
+++ b/src/commands/autocomplete.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use structopt::{clap::Shell, StructOpt};
 
-use crate::{Opt, Result, EXECUTABLE_NAME};
+use crate::{constants::EXECUTABLE_NAME, Opt, Result};
 
 pub fn run<W>(shell: Shell, buf: &mut W) -> Result<()>
 where

--- a/src/commands/install/pip.rs
+++ b/src/commands/install/pip.rs
@@ -9,9 +9,10 @@ use semver::Version;
 
 use crate::{
     commands,
+    constants::EXECUTABLE_NAME,
     dir_monitor::DirectoryMonitor,
     utils::{self, directory::PycorsPathsProviderFromEnv},
-    Result, EXECUTABLE_NAME,
+    Result,
 };
 
 pub fn install_extra_pip_packages(

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -4,6 +4,7 @@ use prettytable::{cell, row, Cell, Row, Table};
 use semver::VersionReq;
 
 use crate::{
+    constants::EXECUTABLE_NAME,
     toolchain::{
         find_installed_toolchains, installed::InstalledToolchain, is_a_custom_install,
         SelectedToolchain, ToolchainFile,
@@ -108,7 +109,7 @@ impl ToolChainTable {
         table.add_row(row![
             "Active",
             "Version",
-            &format!("Installed by {}", crate::EXECUTABLE_NAME),
+            &format!("Installed by {}", EXECUTABLE_NAME),
             "Location"
         ]);
 

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -9,7 +9,10 @@ use structopt::clap::Shell;
 use crate::{
     commands,
     constants::{EXECUTABLE_NAME, EXTRA_PACKAGES_FILENAME_CONTENT},
-    utils::{self, directory::PycorsPathsProviderFromEnv},
+    utils::{
+        self,
+        directory::{PycorsHomeProviderTrait, PycorsPathsProviderFromEnv},
+    },
     Result,
 };
 
@@ -92,7 +95,8 @@ pub fn run(shell: Shell) -> Result<()> {
     }
 
     let extra_packages_file_default_content = EXTRA_PACKAGES_FILENAME_CONTENT;
-    let output_filename = PycorsPathsProviderFromEnv::new().default_extra_package_file();
+    let paths_provider = PycorsPathsProviderFromEnv::new();
+    let output_filename = paths_provider.default_extra_package_file();
     log::debug!(
         "Writing list of default packages to install to {:?}",
         output_filename
@@ -103,8 +107,7 @@ pub fn run(shell: Shell) -> Result<()> {
     // Add ~/.EXECUTABLE_NAME/shims to $PATH in ~/.bashrc and ~/.bash_profile and install autocomplete
     match shell {
         Shell::Bash => {
-            let home =
-                dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Error getting home directory"))?;
+            let home = paths_provider.home()?;
 
             bash::setup_bash(&home)?;
         }

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -8,8 +8,9 @@ use structopt::clap::Shell;
 
 use crate::{
     commands,
+    constants::{EXECUTABLE_NAME, EXTRA_PACKAGES_FILENAME_CONTENT},
     utils::{self, directory::PycorsPathsProviderFromEnv},
-    Result, EXECUTABLE_NAME, EXTRA_PACKAGES_FILENAME_CONTENT,
+    Result,
 };
 
 pub mod bash;

--- a/src/dir_monitor.rs
+++ b/src/dir_monitor.rs
@@ -50,7 +50,7 @@ impl DirectoryMonitor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::EXECUTABLE_NAME;
+    use crate::constants::EXECUTABLE_NAME;
     use std::{
         env,
         fs::{create_dir_all, remove_dir_all, File},

--- a/src/dir_monitor.rs
+++ b/src/dir_monitor.rs
@@ -50,7 +50,7 @@ impl DirectoryMonitor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{tests::temp_dir};
+    use crate::tests::temp_dir;
     use std::{
         fs::{create_dir_all, remove_dir_all, File},
         io::Write,

--- a/src/dir_monitor.rs
+++ b/src/dir_monitor.rs
@@ -50,9 +50,8 @@ impl DirectoryMonitor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::constants::EXECUTABLE_NAME;
+    use crate::{tests::temp_dir};
     use std::{
-        env,
         fs::{create_dir_all, remove_dir_all, File},
         io::Write,
     };
@@ -65,9 +64,7 @@ mod tests {
 
     #[test]
     fn one_file() {
-        let tmp_dir = env::temp_dir()
-            .join(&format!("{}_tests", EXECUTABLE_NAME))
-            .join("one_file");
+        let tmp_dir = temp_dir("dir_monitor", "one_file");
         let _ = remove_dir_all(&tmp_dir);
         create_dir_all(&tmp_dir).unwrap();
 

--- a/src/download.rs
+++ b/src/download.rs
@@ -219,7 +219,9 @@ fn create_download_progress_bar(msg: &str, length: Option<u64>) -> ProgressBar {
 mod tests {
     use super::*;
 
-    use std::{env, fs};
+    use std::fs;
+
+    use crate::tests::temp_dir;
 
     struct MockDownloader {
         chunks: Vec<Result<Bytes>>,
@@ -251,12 +253,6 @@ mod tests {
         }
     }
 
-    fn temp_dir() -> PathBuf {
-        env::temp_dir()
-            .join(crate::constants::EXECUTABLE_NAME)
-            .join("download")
-    }
-
     #[test]
     fn hyper_downloader_success_new() {
         let url = "http://example.com/";
@@ -273,7 +269,7 @@ mod tests {
     #[test]
     fn hyper_downloader_success_get() {
         let mut rt = tokio::runtime::Runtime::new().unwrap();
-        let download_dir = temp_dir().join("hyper_downloader_success_get");
+        let download_dir = temp_dir("download", "hyper_downloader_success_get");
         let downloaded_file = download_dir.join("index.html");
         if download_dir.exists() {
             fs::remove_dir_all(&download_dir).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,94 @@
+mod cache;
+pub mod commands;
+pub mod constants;
+mod dir_monitor;
+mod download;
+mod os;
+pub mod shim;
+mod toolchain;
+mod utils;
+
+pub use anyhow::Result;
+pub use structopt::StructOpt;
+pub use thiserror::Error;
+
+use git_testament::{git_testament, render_testament};
+use lazy_static::lazy_static;
+
+git_testament!(GIT_TESTAMENT);
+
+fn git_version() -> &'static str {
+    lazy_static! {
+        static ref RENDERED: String = render_testament!(GIT_TESTAMENT);
+    }
+    &RENDERED
+}
+
+/// Control which Python toolchain to use on a directory basis.
+#[derive(StructOpt, Debug)]
+#[structopt(version = git_version())]
+pub struct Opt {
+    /// Verbose mode (-v, -vv, -vvv, etc.)
+    #[structopt(short, long, parse(from_occurrences))]
+    pub verbose: u8,
+
+    #[structopt(subcommand)]
+    pub subcommand: Option<commands::Command>,
+}
+
+#[cfg(test)]
+pub mod tests {
+    use std::{env, fs, path::PathBuf};
+
+    pub fn init_logger() {
+        env::var("RUST_LOG")
+            .or_else(|_| -> Result<String, ()> {
+                let rust_log = "debug".to_string();
+                println!("Environment variable 'RUST_LOG' not set.");
+                println!("Setting to: {}", rust_log);
+                env::set_var("RUST_LOG", &rust_log);
+                Ok(rust_log)
+            })
+            .unwrap();
+        let _ = env_logger::try_init();
+    }
+
+    pub fn temp_dir(module: &str, subdir: &str) -> PathBuf {
+        let dir = env::temp_dir()
+            .join(crate::constants::EXECUTABLE_NAME)
+            .join(module);
+
+        if !dir.exists() {
+            fs::create_dir_all(&dir).unwrap();
+        }
+        let dir = dir.canonicalize().unwrap().join(subdir);
+
+        if dir.exists() {
+            fs::remove_dir_all(&dir).unwrap();
+        }
+
+        fs::create_dir_all(&dir).unwrap();
+
+        dir
+    }
+
+    // Version is reported as "unknown" in GitHub Actions.
+    // See https://github.com/nbigaouette/pycors/pull/90/checks?check_run_id=311900597
+    #[test]
+    #[ignore]
+    fn version() {
+        let crate_version = structopt::clap::crate_version!();
+
+        // GIT_VERSION is of the shape `v0.1.7-1-g095d7f5-modified`
+
+        // Strip out the `v` prefix
+        let (v, git_version_without_v) = crate::git_version().split_at(1);
+
+        println!("crate_version: {:?}", crate_version);
+        println!("v: {}", v);
+        println!("git_version_without_v: {}", git_version_without_v);
+
+        assert_eq!(v, "v");
+        assert!(git_version_without_v.starts_with(crate_version));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,45 +13,13 @@ use std::{
     path::PathBuf,
 };
 
-use git_testament::{git_testament, render_testament};
-use lazy_static::lazy_static;
-use structopt::StructOpt;
-
-mod cache;
-mod commands;
-mod constants;
-mod dir_monitor;
-mod download;
-mod os;
-mod shim;
-mod toolchain;
-mod utils;
-
-use crate::{commands::Command, constants::*};
-
-use anyhow::Result;
 use thiserror::Error;
 
-git_testament!(GIT_TESTAMENT);
-
-fn git_version() -> &'static str {
-    lazy_static! {
-        static ref RENDERED: String = render_testament!(GIT_TESTAMENT);
-    }
-    &RENDERED
-}
-
-/// Control which Python toolchain to use on a directory basis.
-#[derive(StructOpt, Debug)]
-#[structopt(version = git_version())]
-struct Opt {
-    /// Verbose mode (-v, -vv, -vvv, etc.)
-    #[structopt(short, long, parse(from_occurrences))]
-    verbose: u8,
-
-    #[structopt(subcommand)]
-    subcommand: Option<commands::Command>,
-}
+use pycors::{
+    commands::{self, Command},
+    constants::EXECUTABLE_NAME,
+    shim, Opt, Result, StructOpt,
+};
 
 #[derive(Debug, Error)]
 pub enum MainError {
@@ -124,61 +92,4 @@ pub fn python_shim(command: &str) -> Result<()> {
     let (_, remaining_args) = arguments.split_at(1);
 
     shim::run(command, remaining_args)
-}
-
-#[cfg(test)]
-pub mod tests {
-    use std::{env, fs, path::PathBuf};
-
-    pub fn init_logger() {
-        env::var("RUST_LOG")
-            .or_else(|_| -> Result<String, ()> {
-                let rust_log = "debug".to_string();
-                println!("Environment variable 'RUST_LOG' not set.");
-                println!("Setting to: {}", rust_log);
-                env::set_var("RUST_LOG", &rust_log);
-                Ok(rust_log)
-            })
-            .unwrap();
-        let _ = env_logger::try_init();
-    }
-
-    pub fn temp_dir(module: &str, subdir: &str) -> PathBuf {
-        let dir = env::temp_dir()
-            .join(crate::constants::EXECUTABLE_NAME)
-            .join(module);
-
-        if !dir.exists() {
-            fs::create_dir_all(&dir).unwrap();
-        }
-        let dir = dir.canonicalize().unwrap().join(subdir);
-
-        if dir.exists() {
-            fs::remove_dir_all(&dir).unwrap();
-        }
-
-        fs::create_dir_all(&dir).unwrap();
-
-        dir
-    }
-
-    // Version is reported as "unknown" in GitHub Actions.
-    // See https://github.com/nbigaouette/pycors/pull/90/checks?check_run_id=311900597
-    #[test]
-    #[ignore]
-    fn version() {
-        let crate_version = structopt::clap::crate_version!();
-
-        // GIT_VERSION is of the shape `v0.1.7-1-g095d7f5-modified`
-
-        // Strip out the `v` prefix
-        let (v, git_version_without_v) = crate::git_version().split_at(1);
-
-        println!("crate_version: {:?}", crate_version);
-        println!("v: {}", v);
-        println!("git_version_without_v: {}", git_version_without_v);
-
-        assert_eq!(v, "v");
-        assert!(git_version_without_v.starts_with(crate_version));
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+// FIXME: Get rid of utils::path_exists(), use std::Path::exists() instead.
 // FIXME: Running '/usr/bin/python2 -V' returns Python 2.7.15+, which fails parsing: ERROR pycors::settings] Failed to parse version string "2.7.15+": ParseError("Error parsing prerelease")
 // FIXME: Replace 'format_err!()' with structs/enums
 // FIXME: Gracefully handle errors that bubble to main
@@ -127,7 +128,7 @@ pub fn python_shim(command: &str) -> Result<()> {
 
 #[cfg(test)]
 pub mod tests {
-    use std::env;
+    use std::{env, fs, path::PathBuf};
 
     pub fn init_logger() {
         env::var("RUST_LOG")
@@ -140,6 +141,25 @@ pub mod tests {
             })
             .unwrap();
         let _ = env_logger::try_init();
+    }
+
+    pub fn temp_dir(module: &str, subdir: &str) -> PathBuf {
+        let dir = env::temp_dir()
+            .join(crate::constants::EXECUTABLE_NAME)
+            .join(module);
+
+        if !dir.exists() {
+            fs::create_dir_all(&dir).unwrap();
+        }
+        let dir = dir.canonicalize().unwrap().join(subdir);
+
+        if dir.exists() {
+            fs::remove_dir_all(&dir).unwrap();
+        }
+
+        fs::create_dir_all(&dir).unwrap();
+
+        dir
     }
 
     // Version is reported as "unknown" in GitHub Actions.

--- a/src/os.rs
+++ b/src/os.rs
@@ -23,6 +23,7 @@ pub fn paths_to_prepends(version: &Version) -> Result<Vec<PathBuf>> {
 
     let mut paths = Vec::new();
 
+    #[allow(clippy::redundant_clone)]
     paths.push(bin_dir.clone());
 
     #[cfg(windows)]

--- a/src/shim.rs
+++ b/src/shim.rs
@@ -6,12 +6,12 @@ use semver::VersionReq;
 use thiserror::Error;
 
 use crate::{
+    constants::EXECUTABLE_NAME,
     dir_monitor::DirectoryMonitor,
     os,
     toolchain::{installed::InstalledToolchain, CompatibleToolchainBuilder},
     utils,
     utils::directory::PycorsPathsProviderFromEnv,
-    EXECUTABLE_NAME,
 };
 
 #[derive(Debug, Error)]

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -14,12 +14,12 @@ use thiserror::Error;
 use which::which_in;
 
 use crate::{
-    constants::TOOLCHAIN_FILE,
+    constants::{EXECUTABLE_NAME, TOOLCHAIN_FILE},
     utils::{
         self,
         directory::{PycorsHomeProviderTrait, PycorsPathsProvider, PycorsPathsProviderFromEnv},
     },
-    Result, EXECUTABLE_NAME,
+    Result,
 };
 
 pub mod installed;
@@ -374,7 +374,7 @@ where
 }
 
 fn _is_a_custom_install(path: &Path) -> bool {
-    if path.join(crate::INFO_FILE).exists() {
+    if path.join(crate::constants::INFO_FILE).exists() {
         true
     } else {
         match path.parent() {

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -382,7 +382,7 @@ fn _is_a_custom_install(path: &Path) -> bool {
                 // Cannot get parent directory, probably at root.
                 false
             }
-            Some(parent) => is_a_custom_install(parent),
+            Some(parent) => _is_a_custom_install(parent),
         }
     }
 }

--- a/src/toolchain/installed.rs
+++ b/src/toolchain/installed.rs
@@ -10,8 +10,8 @@ use semver::{Version, VersionReq};
 use thiserror::Error;
 
 use crate::{
-    constants::{INFO_FILE, TOOLCHAIN_FILE},
-    toolchain::get_python_versions_from_path,
+    constants::TOOLCHAIN_FILE,
+    toolchain::{self, get_python_versions_from_path},
     utils::directory::PycorsPathsProviderFromEnv,
 };
 
@@ -59,13 +59,7 @@ impl InstalledToolchain {
     }
 
     pub fn is_custom_install(&self) -> bool {
-        match self.location.parent() {
-            None => {
-                log::error!("Cannot get parent directory of {:?}", self.location);
-                false
-            }
-            Some(parent) => parent.join(INFO_FILE).exists(),
-        }
+        toolchain::is_a_custom_install(&self.location)
     }
 
     pub fn save_version(&self) -> Result<usize> {

--- a/src/toolchain/installed.rs
+++ b/src/toolchain/installed.rs
@@ -10,7 +10,8 @@ use semver::{Version, VersionReq};
 use thiserror::Error;
 
 use crate::{
-    constants::TOOLCHAIN_FILE, toolchain::get_python_versions_from_path,
+    constants::{INFO_FILE, TOOLCHAIN_FILE},
+    toolchain::get_python_versions_from_path,
     utils::directory::PycorsPathsProviderFromEnv,
 };
 
@@ -63,7 +64,7 @@ impl InstalledToolchain {
                 log::error!("Cannot get parent directory of {:?}", self.location);
                 false
             }
-            Some(parent) => parent.join(crate::INFO_FILE).exists(),
+            Some(parent) => parent.join(INFO_FILE).exists(),
         }
     }
 

--- a/src/toolchain/tests.rs
+++ b/src/toolchain/tests.rs
@@ -65,19 +65,25 @@ fn _mock_executable(
     ));
 
     if stdout_filepath.exists() {
-        fs::remove_file(&stdout_filepath)?;
+        fs::remove_file(&stdout_filepath)
+            .with_context(|| format!("Failed to remove file {:?}", stdout_filepath))?;
     }
     if stderr_filepath.exists() {
-        fs::remove_file(&stderr_filepath)?;
+        fs::remove_file(&stderr_filepath)
+            .with_context(|| format!("Failed to remove file {:?}", stderr_filepath))?;
     }
 
     if let Some(stdout) = output.out {
-        let mut f = File::create(stdout_filepath)?;
-        f.write_all(stdout.as_bytes())?;
+        let mut f = File::create(&stdout_filepath)
+            .with_context(|| format!("Failed to create file {:?}", stdout_filepath))?;
+        f.write_all(stdout.as_bytes())
+            .with_context(|| format!("Failed to write to file {:?}", stdout_filepath))?;
     }
     if let Some(stderr) = output.err {
-        let mut f = File::create(stderr_filepath)?;
-        f.write_all(stderr.as_bytes())?;
+        let mut f = File::create(&stderr_filepath)
+            .with_context(|| format!("Failed to create file {:?}", stderr_filepath))?;
+        f.write_all(stderr.as_bytes())
+            .with_context(|| format!("Failed to write to file {:?}", stderr_filepath))?;
     }
 
     let print_file_to_stdout = {
@@ -95,7 +101,14 @@ fn _mock_executable(
     fs::copy(
         &print_file_to_stdout,
         executable_location.join(format!("{}{}", executable_name, EXEC_EXTENSION)),
-    )?;
+    )
+    .with_context(|| {
+        format!(
+            "Failed to copy {:?} to {:?}",
+            print_file_to_stdout,
+            executable_location.join(format!("{}{}", executable_name, EXEC_EXTENSION))
+        )
+    })?;
 
     Ok(())
 }

--- a/src/toolchain/tests.rs
+++ b/src/toolchain/tests.rs
@@ -733,8 +733,6 @@ fn get_python_versions_from_path_failure_to_run() {
 
     #[cfg(not(windows))]
     {
-        crate::tests::init_logger();
-
         let pycors_home = temp_dir("toolchain", "get_python_versions_from_path_failure_to_run");
 
         let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
@@ -784,8 +782,6 @@ fn is_a_custom_install_false() {
 
 #[test]
 fn find_installed_toolchains_absent_dir() {
-    crate::tests::init_logger();
-
     let test_dir = temp_dir("toolchain", "find_installed_toolchains_absent_dir");
     let pycors_home = test_dir.join(".pycors");
     let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
@@ -814,8 +810,6 @@ fn find_installed_toolchains_absent_dir() {
 
 #[test]
 fn find_installed_toolchains_empty_installed_dir() {
-    crate::tests::init_logger();
-
     let test_dir = temp_dir("toolchain", "find_installed_toolchains_empty_installed_dir");
     let pycors_home = test_dir.join(".pycors");
     let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
@@ -847,8 +841,6 @@ fn find_installed_toolchains_empty_installed_dir() {
 
 #[test]
 fn find_installed_toolchains_dummy_custom_installs() {
-    crate::tests::init_logger();
-
     let test_dir = temp_dir(
         "toolchain",
         "find_installed_toolchains_dummy_custom_installs",
@@ -929,8 +921,6 @@ fn find_installed_toolchains_dummy_custom_installs() {
 
 #[test]
 fn find_installed_toolchains_dummy_system_installs() {
-    crate::tests::init_logger();
-
     let test_dir = temp_dir(
         "toolchain",
         "find_installed_toolchains_dummy_system_installs",
@@ -1021,7 +1011,6 @@ fn find_installed_toolchains_dummy_system_installs() {
 
 #[test]
 fn find_compatible_toolchain_macos_default() {
-    crate::tests::init_logger();
     let installed_toolchains: &[InstalledToolchain] = &[InstalledToolchain {
         location: PathBuf::from("/usr/bin"),
         version: Version::parse("2.7.17").unwrap(),
@@ -1069,8 +1058,6 @@ fn find_compatible_toolchain_macos_default() {
 
 #[test]
 fn find_compatible_toolchain_multiple() {
-    crate::tests::init_logger();
-
     let test_dir = temp_dir("toolchain", "find_compatible_toolchain_multiple");
     let pycors_home = test_dir.join(".pycors");
 
@@ -1152,8 +1139,6 @@ fn find_compatible_toolchain_multiple() {
 
 #[test]
 fn find_compatible_toolchain_same_system_custom() {
-    crate::tests::init_logger();
-
     let test_dir = temp_dir("toolchain", "find_compatible_toolchain_same_system_custom");
     let pycors_home = test_dir.join(".pycors");
 
@@ -1212,8 +1197,6 @@ fn find_compatible_toolchain_same_system_custom() {
 
 #[test]
 fn compatible_toolchain_builder_load_from_string() {
-    crate::tests::init_logger();
-
     let test_dir = temp_dir("toolchain", "compatible_toolchain_builder_load_from_string");
     let pycors_home = test_dir.join(".pycors");
     let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());

--- a/src/toolchain/tests.rs
+++ b/src/toolchain/tests.rs
@@ -87,8 +87,13 @@ fn _mock_executable(
     }
 
     let print_file_to_stdout = {
+        let target_dir = match env::var("CARGO_TARGET_DIR") {
+            Ok(dir) => dir,
+            Err(_) => String::from("target"),
+        };
+
         #[cfg_attr(not(windows), allow(unused_mut))]
-        let mut tmp = Path::new("target")
+        let mut tmp = Path::new(&target_dir)
             .join("debug")
             .join("print_file_to_stdout");
 

--- a/src/toolchain/tests.rs
+++ b/src/toolchain/tests.rs
@@ -13,7 +13,7 @@ use std::{
     process::{ExitStatus, Output},
 };
 
-use crate::{tests::temp_dir, utils::directory::MockPycorsHomeProviderTrait};
+use crate::{constants::INFO_FILE, tests::temp_dir, utils::directory::MockPycorsHomeProviderTrait};
 
 #[cfg(windows)]
 const EXEC_EXTENSION: &str = ".exe";
@@ -725,7 +725,7 @@ fn get_python_versions_from_path_failure_to_run() {
 #[test]
 fn is_a_custom_install_true() {
     let dir = temp_dir("toolchain", "is_a_custom_install_true");
-    let info_filename = dir.join(crate::INFO_FILE);
+    let info_filename = dir.join(INFO_FILE);
     // Create file in directory
     let mut f = File::create(info_filename).unwrap();
     f.write_all(b"").unwrap();
@@ -1126,7 +1126,7 @@ fn find_compatible_toolchain_same_system_custom() {
         &installed_toolchains[2].location,
     ] {
         fs::create_dir_all(&location).unwrap();
-        let info_filename = location.parent().unwrap().join(crate::INFO_FILE);
+        let info_filename = location.parent().unwrap().join(INFO_FILE);
         // Create file in directory
         let mut f = File::create(info_filename).unwrap();
         f.write_all(b"").unwrap();

--- a/src/toolchain/tests.rs
+++ b/src/toolchain/tests.rs
@@ -544,12 +544,16 @@ fn get_python_versions_from_path_pycors_home_dir_absent() {
 #[test]
 fn get_python_versions_from_path_shim_dir_absent() {
     let pycors_home = temp_dir("toolchain", "get_python_versions_from_path_shim_dir_absent");
+    let mocked_home = pycors_home.clone();
     let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
 
     let mut mock = MockPycorsHomeProviderTrait::new();
     mock.expect_home_env_variable()
         .times(1)
         .return_const(mocked_pycors_home);
+    mock.expect_home()
+        .times(1)
+        .returning(move || Ok(mocked_home.clone()));
     let paths_provider = PycorsPathsProvider::from(mock);
 
     let python_versions = get_python_versions_from_path(&pycors_home, &paths_provider);
@@ -560,12 +564,16 @@ fn get_python_versions_from_path_shim_dir_absent() {
 #[test]
 fn get_python_versions_from_path_shim_skipped() {
     let pycors_home = temp_dir("toolchain", "get_python_versions_from_path_shim_skipped");
+    let mocked_home = pycors_home.clone();
     let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
 
     let mut mock = MockPycorsHomeProviderTrait::new();
     mock.expect_home_env_variable()
-        .times(1 + 1) // We need the shim dir to call function, hence +1
+        .times(2) // We need the shim dir to call function, hence +1
         .return_const(mocked_pycors_home);
+    mock.expect_home()
+        .times(2)
+        .returning(move || Ok(mocked_home.clone()));
     let paths_provider = PycorsPathsProvider::from(mock);
 
     let shims_dir = paths_provider.shims();
@@ -582,12 +590,16 @@ fn get_python_versions_from_path_2717_and_374_and_375() {
         "toolchain",
         "get_python_versions_from_path_2717_and_374_and_375",
     );
+    let mocked_home = pycors_home.clone();
     let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
 
     let mut mock = MockPycorsHomeProviderTrait::new();
     mock.expect_home_env_variable()
-        .times(1 + 1)
+        .times(2)
         .return_const(mocked_pycors_home);
+    mock.expect_home()
+        .times(2)
+        .returning(move || Ok(mocked_home.clone()));
     let paths_provider = PycorsPathsProvider::from(mock);
 
     let shims_dir = paths_provider.shims();
@@ -644,12 +656,16 @@ fn get_python_versions_from_path_single_word_wont_parse() {
         "toolchain",
         "get_python_versions_from_path_single_word_wont_parse",
     );
+    let mocked_home = pycors_home.clone();
     let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
 
     let mut mock = MockPycorsHomeProviderTrait::new();
     mock.expect_home_env_variable()
-        .times(1 + 1)
+        .times(2)
         .return_const(mocked_pycors_home);
+    mock.expect_home()
+        .times(2)
+        .returning(move || Ok(mocked_home.clone()));
     let paths_provider = PycorsPathsProvider::from(mock);
 
     let shims_dir = paths_provider.shims();
@@ -677,11 +693,15 @@ fn get_python_versions_from_path_non_version_wont_parse() {
         "get_python_versions_from_path_non_version_wont_parse",
     );
     let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
+    let mocked_home = pycors_home.clone();
 
     let mut mock = MockPycorsHomeProviderTrait::new();
     mock.expect_home_env_variable()
-        .times(1 + 1)
+        .times(2)
         .return_const(mocked_pycors_home);
+    mock.expect_home()
+        .times(2)
+        .returning(move || Ok(mocked_home.clone()));
     let paths_provider = PycorsPathsProvider::from(mock);
 
     let shims_dir = paths_provider.shims();
@@ -714,13 +734,19 @@ fn get_python_versions_from_path_failure_to_run() {
     #[cfg(not(windows))]
     {
         crate::tests::init_logger();
+
         let pycors_home = temp_dir("toolchain", "get_python_versions_from_path_failure_to_run");
+
         let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
+        let mocked_home = pycors_home.clone();
 
         let mut mock = MockPycorsHomeProviderTrait::new();
         mock.expect_home_env_variable()
-            .times(1 + 1)
+            .times(2)
             .return_const(mocked_pycors_home);
+        mock.expect_home()
+            .times(2)
+            .returning(move || Ok(mocked_home.clone()));
         let paths_provider = PycorsPathsProvider::from(mock);
 
         let shims_dir = paths_provider.shims();
@@ -775,6 +801,9 @@ fn find_installed_toolchains_absent_dir() {
     mock.expect_home_env_variable()
         .times(1)
         .return_const(mocked_pycors_home);
+    mock.expect_home()
+        .times(1)
+        .returning(move || Ok(test_dir.clone()));
     mock.expect_paths().times(1).return_const(mocked_paths);
     let paths_provider = PycorsPathsProvider::from(mock);
 
@@ -802,6 +831,9 @@ fn find_installed_toolchains_empty_installed_dir() {
     mock.expect_home_env_variable()
         .times(2)
         .return_const(mocked_pycors_home);
+    mock.expect_home()
+        .times(2)
+        .returning(move || Ok(test_dir.clone()));
     mock.expect_paths().times(1).return_const(mocked_paths);
     let paths_provider = PycorsPathsProvider::from(mock);
 
@@ -835,6 +867,9 @@ fn find_installed_toolchains_dummy_custom_installs() {
     mock.expect_home_env_variable()
         .times(4)
         .return_const(mocked_pycors_home);
+    mock.expect_home()
+        .times(4)
+        .returning(move || Ok(test_dir.clone()));
     mock.expect_paths().times(1).return_const(mocked_paths);
     let paths_provider = PycorsPathsProvider::from(mock);
 
@@ -914,6 +949,9 @@ fn find_installed_toolchains_dummy_system_installs() {
     mock.expect_home_env_variable()
         .times(4)
         .return_const(mocked_pycors_home);
+    mock.expect_home()
+        .times(4)
+        .returning(move || Ok(test_dir.clone()));
     mock.expect_paths().times(1).return_const(mocked_paths);
     let paths_provider = PycorsPathsProvider::from(mock);
 
@@ -1188,6 +1226,9 @@ fn compatible_toolchain_builder_load_from_string() {
     mock.expect_home_env_variable()
         .times(1)
         .return_const(mocked_pycors_home);
+    mock.expect_home()
+        .times(1)
+        .returning(move || Ok(test_dir.clone()));
     mock.expect_paths().times(1).return_const(mocked_paths);
     let paths_provider = PycorsPathsProvider::from(mock);
     let compatible_toolchain = CompatibleToolchainBuilder::new()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -441,13 +441,7 @@ pub enum SpinnerMessage {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn temp_dir() -> PathBuf {
-        env::temp_dir()
-            .join(crate::constants::EXECUTABLE_NAME)
-            .join("utils")
-            .join("tests")
-    }
+    use crate::tests::temp_dir;
 
     fn fixture_installed_toolchains() -> Vec<InstalledToolchain> {
         vec![
@@ -486,7 +480,7 @@ mod tests {
 
     #[test]
     fn copy_file_success() {
-        let tmp_dir = temp_dir().join("copy_file_success");
+        let tmp_dir = temp_dir("utils", "copy_file_success");
         if tmp_dir.exists() {
             fs::remove_dir_all(&tmp_dir).unwrap()
         };
@@ -609,7 +603,7 @@ mod tests {
 
     #[test]
     fn create_info_file_success() {
-        let tmp_dir = temp_dir().join("create_info_file_success");
+        let tmp_dir = temp_dir("utils", "create_info_file_success");
         if tmp_dir.exists() {
             fs::remove_dir_all(&tmp_dir).unwrap()
         };

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,7 +13,12 @@ use indicatif::{ProgressBar, ProgressStyle};
 use semver::{Version, VersionReq};
 use terminal_size::{terminal_size, Width};
 
-use crate::{os, toolchain::installed::InstalledToolchain, Result};
+use crate::{
+    constants::{EXECUTABLE_NAME, INFO_FILE},
+    os,
+    toolchain::installed::InstalledToolchain,
+    Result,
+};
 
 pub mod directory;
 
@@ -163,7 +168,7 @@ pub fn get_info_file<P>(install_dir: P) -> PathBuf
 where
     P: AsRef<Path>,
 {
-    install_dir.as_ref().join(crate::INFO_FILE)
+    install_dir.as_ref().join(INFO_FILE)
 }
 
 pub fn create_info_file<P>(install_dir: P, version: &Version) -> Result<()>
@@ -176,7 +181,7 @@ where
         file,
         "Python {} installed using {} version {} on {}.\n",
         version,
-        crate::EXECUTABLE_NAME,
+        EXECUTABLE_NAME,
         crate::git_version(),
         chrono::Local::now().to_rfc3339()
     )?;
@@ -598,7 +603,7 @@ mod tests {
     fn get_info_file_success() {
         let dir = Path::new("unimportant");
         let file = get_info_file(&dir);
-        let expected = dir.join(crate::INFO_FILE);
+        let expected = dir.join(INFO_FILE);
         assert_eq!(file, expected);
     }
 
@@ -610,7 +615,7 @@ mod tests {
         };
         fs::create_dir_all(&tmp_dir).unwrap();
         let version = Version::new(3, 7, 5);
-        let expected_file_path = tmp_dir.join(crate::INFO_FILE);
+        let expected_file_path = tmp_dir.join(INFO_FILE);
         let expected_file_begin = "Python 3.7.5 installed using ";
         assert!(!expected_file_path.exists());
         create_info_file(&tmp_dir, &version).unwrap();

--- a/src/utils/directory.rs
+++ b/src/utils/directory.rs
@@ -219,8 +219,10 @@ pub mod tests {
 
         #[test]
         fn config_home_from_default() {
+            let home = default_home_full_path();
             let pycors_home = default_dot_full_path();
 
+            let mocked_home = Ok(home);
             let mocked_pycors_home = None;
 
             let expected = pycors_home;
@@ -229,6 +231,7 @@ pub mod tests {
             mock.expect_home_env_variable()
                 .times(1)
                 .return_const(mocked_pycors_home);
+            mock.expect_home().times(1).return_once(move || mocked_home);
 
             let paths_provider = PycorsPathsProvider::from(mock);
             let to_validate = paths_provider.config_home();
@@ -237,8 +240,10 @@ pub mod tests {
 
         #[test]
         fn config_home_from_env_variable() {
+            let home = default_home_full_path();
             let pycors_home = temp_dir().join("config_home_from_env_variable");
 
+            let mocked_home = Ok(home);
             let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
 
             let expected = pycors_home;
@@ -247,6 +252,7 @@ pub mod tests {
             mock.expect_home_env_variable()
                 .times(1)
                 .return_const(mocked_pycors_home);
+            mock.expect_home().times(1).return_once(move || mocked_home);
 
             let paths_provider = PycorsPathsProvider::from(mock);
             let to_validate = paths_provider.config_home();
@@ -255,8 +261,10 @@ pub mod tests {
 
         #[test]
         fn default_extra_package_file_from_default() {
+            let home = default_home_full_path();
             let pycors_home = default_dot_full_path();
 
+            let mocked_home = Ok(home);
             let mocked_pycors_home = None;
 
             let expected = pycors_home.join(EXTRA_PACKAGES_FILENAME);
@@ -265,6 +273,7 @@ pub mod tests {
             mock.expect_home_env_variable()
                 .times(1)
                 .return_const(mocked_pycors_home);
+            mock.expect_home().times(1).return_once(move || mocked_home);
 
             let paths_provider = PycorsPathsProvider::from(mock);
             let to_validate = paths_provider.default_extra_package_file();
@@ -273,15 +282,18 @@ pub mod tests {
 
         #[test]
         fn default_extra_package_file_from_env_variable() {
+            let home = default_home_full_path();
             let pycors_home = temp_dir().join("default_extra_package_file_from_env");
             let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
 
+            let mocked_home = Ok(home);
             let expected = pycors_home.join(EXTRA_PACKAGES_FILENAME);
 
             let mut mock = MockPycorsHomeProviderTrait::new();
             mock.expect_home_env_variable()
                 .times(1)
                 .return_const(mocked_pycors_home);
+            mock.expect_home().times(1).return_once(move || mocked_home);
 
             let paths_provider = PycorsPathsProvider::from(mock);
             let to_validate = paths_provider.default_extra_package_file();
@@ -290,8 +302,10 @@ pub mod tests {
 
         #[test]
         fn cache_from_default() {
+            let home = default_home_full_path();
             let pycors_home = default_dot_full_path();
 
+            let mocked_home = Ok(home);
             let mocked_pycors_home = None;
 
             let expected = pycors_home.join("cache");
@@ -300,6 +314,7 @@ pub mod tests {
             mock.expect_home_env_variable()
                 .times(1)
                 .return_const(mocked_pycors_home);
+            mock.expect_home().times(1).return_once(move || mocked_home);
 
             let paths_provider = PycorsPathsProvider::from(mock);
             let to_validate = paths_provider.cache();
@@ -308,7 +323,10 @@ pub mod tests {
 
         #[test]
         fn cache_from_env_variable() {
+            let home = default_home_full_path();
             let pycors_home = temp_dir().join("cache_from_env");
+
+            let mocked_home = Ok(home);
             let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
 
             let expected = pycors_home.join("cache");
@@ -317,6 +335,7 @@ pub mod tests {
             mock.expect_home_env_variable()
                 .times(1)
                 .return_const(mocked_pycors_home);
+            mock.expect_home().times(1).return_once(move || mocked_home);
 
             let paths_provider = PycorsPathsProvider::from(mock);
             let to_validate = paths_provider.cache();
@@ -325,8 +344,10 @@ pub mod tests {
 
         #[test]
         fn installed_from_default() {
+            let home = default_home_full_path();
             let pycors_home = default_dot_full_path();
 
+            let mocked_home = Ok(home);
             let mocked_pycors_home = None;
 
             let expected = pycors_home.join("installed");
@@ -335,6 +356,7 @@ pub mod tests {
             mock.expect_home_env_variable()
                 .times(1)
                 .return_const(mocked_pycors_home);
+            mock.expect_home().times(1).return_once(move || mocked_home);
 
             let paths_provider = PycorsPathsProvider::from(mock);
             let to_validate = paths_provider.installed();
@@ -343,7 +365,10 @@ pub mod tests {
 
         #[test]
         fn installed_from_env_variable() {
+            let home = default_home_full_path();
             let pycors_home = temp_dir().join("installed_from_env");
+
+            let mocked_home = Ok(home);
             let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
 
             let expected = pycors_home.join("installed");
@@ -352,6 +377,7 @@ pub mod tests {
             mock.expect_home_env_variable()
                 .times(1)
                 .return_const(mocked_pycors_home);
+            mock.expect_home().times(1).return_once(move || mocked_home);
 
             let paths_provider = PycorsPathsProvider::from(mock);
             let to_validate = paths_provider.installed();
@@ -360,8 +386,10 @@ pub mod tests {
 
         #[test]
         fn logs_from_default() {
+            let home = default_home_full_path();
             let pycors_home = default_dot_full_path();
 
+            let mocked_home = Ok(home);
             let mocked_pycors_home = None;
 
             let expected = pycors_home.join("logs");
@@ -370,6 +398,7 @@ pub mod tests {
             mock.expect_home_env_variable()
                 .times(1)
                 .return_const(mocked_pycors_home);
+            mock.expect_home().times(1).return_once(move || mocked_home);
 
             let paths_provider = PycorsPathsProvider::from(mock);
             let to_validate = paths_provider.logs();
@@ -378,7 +407,10 @@ pub mod tests {
 
         #[test]
         fn logs_from_env_variable() {
+            let home = default_home_full_path();
             let pycors_home = temp_dir().join("logs_from_env");
+
+            let mocked_home = Ok(home);
             let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
 
             let expected = pycors_home.join("logs");
@@ -387,6 +419,7 @@ pub mod tests {
             mock.expect_home_env_variable()
                 .times(1)
                 .return_const(mocked_pycors_home);
+            mock.expect_home().times(1).return_once(move || mocked_home);
 
             let paths_provider = PycorsPathsProvider::from(mock);
             let to_validate = paths_provider.logs();
@@ -395,8 +428,10 @@ pub mod tests {
 
         #[test]
         fn shims_from_default() {
+            let home = default_home_full_path();
             let pycors_home = default_dot_full_path();
 
+            let mocked_home = Ok(home);
             let mocked_pycors_home = None;
 
             let expected = pycors_home.join("shims");
@@ -405,6 +440,7 @@ pub mod tests {
             mock.expect_home_env_variable()
                 .times(1)
                 .return_const(mocked_pycors_home);
+            mock.expect_home().times(1).return_once(move || mocked_home);
 
             let paths_provider = PycorsPathsProvider::from(mock);
             let to_validate = paths_provider.shims();
@@ -414,6 +450,7 @@ pub mod tests {
         #[test]
         fn shims_from_env_variable() {
             let pycors_home = temp_dir().join("shims_from_env");
+            let mocked_home = Ok(pycors_home.clone());
             let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
 
             let expected = pycors_home.join("shims");
@@ -422,6 +459,7 @@ pub mod tests {
             mock.expect_home_env_variable()
                 .times(1)
                 .return_const(mocked_pycors_home);
+            mock.expect_home().times(1).return_once(move || mocked_home);
 
             let paths_provider = PycorsPathsProvider::from(mock);
             let to_validate = paths_provider.shims();
@@ -430,8 +468,10 @@ pub mod tests {
 
         #[test]
         fn downloaded_from_default() {
+            let home = default_home_full_path();
             let pycors_home = default_dot_full_path();
 
+            let mocked_home = Ok(home);
             let mocked_pycors_home = None;
 
             let expected = pycors_home.join("cache").join("downloaded");
@@ -440,6 +480,7 @@ pub mod tests {
             mock.expect_home_env_variable()
                 .times(1)
                 .return_const(mocked_pycors_home);
+            mock.expect_home().times(1).return_once(move || mocked_home);
 
             let paths_provider = PycorsPathsProvider::from(mock);
             let to_validate = paths_provider.downloaded();
@@ -449,6 +490,7 @@ pub mod tests {
         #[test]
         fn downloaded_from_env_variable() {
             let pycors_home = temp_dir().join("downloaded_from_env");
+            let mocked_home = Ok(pycors_home.clone());
             let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
 
             let expected = pycors_home.join("cache").join("downloaded");
@@ -457,6 +499,7 @@ pub mod tests {
             mock.expect_home_env_variable()
                 .times(1)
                 .return_const(mocked_pycors_home);
+            mock.expect_home().times(1).return_once(move || mocked_home);
 
             let paths_provider = PycorsPathsProvider::from(mock);
             let to_validate = paths_provider.downloaded();
@@ -465,8 +508,10 @@ pub mod tests {
 
         #[test]
         fn available_toolchain_from_default() {
+            let home = default_home_full_path();
             let pycors_home = default_dot_full_path();
 
+            let mocked_home = Ok(home);
             let mocked_pycors_home = None;
 
             let expected = pycors_home.join("cache").join(AVAILABLE_TOOLCHAIN_CACHE);
@@ -475,6 +520,7 @@ pub mod tests {
             mock.expect_home_env_variable()
                 .times(1)
                 .return_const(mocked_pycors_home);
+            mock.expect_home().times(1).return_once(move || mocked_home);
 
             let paths_provider = PycorsPathsProvider::from(mock);
             let to_validate = paths_provider.available_toolchains_cache_file();
@@ -484,6 +530,7 @@ pub mod tests {
         #[test]
         fn available_toolchain_from_env_variable() {
             let pycors_home = temp_dir().join("available_toolchain_from_env");
+            let mocked_home = Ok(pycors_home.clone());
             let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
 
             let expected = pycors_home.join("cache").join(AVAILABLE_TOOLCHAIN_CACHE);
@@ -492,6 +539,7 @@ pub mod tests {
             mock.expect_home_env_variable()
                 .times(1)
                 .return_const(mocked_pycors_home);
+            mock.expect_home().times(1).return_once(move || mocked_home);
 
             let paths_provider = PycorsPathsProvider::from(mock);
             let to_validate = paths_provider.available_toolchains_cache_file();
@@ -500,8 +548,10 @@ pub mod tests {
 
         #[test]
         fn extracted_from_default() {
+            let home = default_home_full_path();
             let pycors_home = default_dot_full_path();
 
+            let mocked_home = Ok(home);
             let mocked_pycors_home = None;
 
             let expected = pycors_home.join("cache").join("extracted");
@@ -510,6 +560,7 @@ pub mod tests {
             mock.expect_home_env_variable()
                 .times(1)
                 .return_const(mocked_pycors_home);
+            mock.expect_home().times(1).return_once(move || mocked_home);
 
             let paths_provider = PycorsPathsProvider::from(mock);
             let to_validate = paths_provider.extracted();
@@ -519,6 +570,7 @@ pub mod tests {
         #[test]
         fn extracted_from_env_variable() {
             let pycors_home = temp_dir().join("extracted_from_env");
+            let mocked_home = Ok(pycors_home.clone());
             let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
 
             let expected = pycors_home.join("cache").join("extracted");
@@ -527,6 +579,7 @@ pub mod tests {
             mock.expect_home_env_variable()
                 .times(1)
                 .return_const(mocked_pycors_home);
+            mock.expect_home().times(1).return_once(move || mocked_home);
 
             let paths_provider = PycorsPathsProvider::from(mock);
             let to_validate = paths_provider.extracted();
@@ -535,11 +588,14 @@ pub mod tests {
 
         #[test]
         fn install_dir_from_default() {
+            let home = default_home_full_path();
             let pycors_home = default_dot_full_path();
+
+            let mocked_home = Ok(home);
+            let mocked_pycors_home = None;
+
             let version_str = "3.7.5";
             let version = Version::parse(version_str).unwrap();
-
-            let mocked_pycors_home = None;
 
             let expected = pycors_home.join("installed").join(version_str);
 
@@ -547,6 +603,7 @@ pub mod tests {
             mock.expect_home_env_variable()
                 .times(1)
                 .return_const(mocked_pycors_home);
+            mock.expect_home().times(1).return_once(move || mocked_home);
 
             let paths_provider = PycorsPathsProvider::from(mock);
             let to_validate = paths_provider.install_dir(&version);
@@ -556,6 +613,7 @@ pub mod tests {
         #[test]
         fn install_dir_from_env_variable() {
             let pycors_home = temp_dir().join("install_dir_from_env");
+            let mocked_home = Ok(pycors_home.clone());
             let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
             let version_str = "3.7.5";
             let version = Version::parse(version_str).unwrap();
@@ -566,6 +624,7 @@ pub mod tests {
             mock.expect_home_env_variable()
                 .times(1)
                 .return_const(mocked_pycors_home);
+            mock.expect_home().times(1).return_once(move || mocked_home);
 
             let paths_provider = PycorsPathsProvider::from(mock);
             let to_validate = paths_provider.install_dir(&version);
@@ -574,10 +633,13 @@ pub mod tests {
 
         #[test]
         fn bin_dir_from_default() {
+            let home = default_home_full_path();
             let pycors_home = default_dot_full_path();
+
             let version_str = "3.7.5";
             let version = Version::parse(version_str).unwrap();
 
+            let mocked_home = Ok(home);
             let mocked_pycors_home = None;
 
             #[cfg(not(windows))]
@@ -589,6 +651,7 @@ pub mod tests {
             mock.expect_home_env_variable()
                 .times(1)
                 .return_const(mocked_pycors_home);
+            mock.expect_home().times(1).return_once(move || mocked_home);
 
             let paths_provider = PycorsPathsProvider::from(mock);
             let to_validate = paths_provider.bin_dir(&version);
@@ -598,6 +661,7 @@ pub mod tests {
         #[test]
         fn bin_dir_from_env_variable() {
             let pycors_home = temp_dir().join("bin_dir_from_env");
+            let mocked_home = Ok(pycors_home.clone());
             let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
             let version_str = "3.7.5";
             let version = Version::parse(version_str).unwrap();
@@ -611,6 +675,7 @@ pub mod tests {
             mock.expect_home_env_variable()
                 .times(1)
                 .return_const(mocked_pycors_home);
+            mock.expect_home().times(1).return_once(move || mocked_home);
 
             let paths_provider = PycorsPathsProvider::from(mock);
             let to_validate = paths_provider.bin_dir(&version);

--- a/src/utils/directory.rs
+++ b/src/utils/directory.rs
@@ -4,8 +4,7 @@ use dirs::home_dir;
 use semver::Version;
 
 use crate::constants::{
-    self, AVAILABLE_TOOLCHAIN_CACHE, DEFAULT_DOT_DIR, EXECUTABLE_NAME,
-    EXTRA_PACKAGES_FILENAME,
+    self, AVAILABLE_TOOLCHAIN_CACHE, DEFAULT_DOT_DIR, EXECUTABLE_NAME, EXTRA_PACKAGES_FILENAME,
 };
 
 fn dot_dir(name: &str) -> Option<PathBuf> {

--- a/src/utils/directory.rs
+++ b/src/utils/directory.rs
@@ -190,11 +190,15 @@ pub mod tests {
 
     mod pycors_paths_trait {
         use super::*;
+        use crate::constants::home_env_variable;
 
         #[test]
         fn path_provider_env() {
-            // FIXME: Detect if PYCORS_HOME is set, use it for 'expected' if set.
-            let expected = dot_dir(DEFAULT_DOT_DIR).unwrap();
+            let expected = match env::var(home_env_variable()) {
+                Ok(dir) => PathBuf::from(dir),
+                Err(_) => dot_dir(DEFAULT_DOT_DIR).unwrap(),
+            };
+
             let paths_provider = PycorsPathsProviderFromEnv::new();
             let to_validate = paths_provider.config_home();
             assert_eq!(to_validate, expected);

--- a/src/utils/directory.rs
+++ b/src/utils/directory.rs
@@ -3,8 +3,11 @@ use std::{env, ffi::OsString, path::PathBuf};
 use dirs::home_dir;
 use semver::Version;
 
-use crate::constants::{
-    self, AVAILABLE_TOOLCHAIN_CACHE, DEFAULT_DOT_DIR, EXECUTABLE_NAME, EXTRA_PACKAGES_FILENAME,
+use crate::{
+    constants::{
+        self, AVAILABLE_TOOLCHAIN_CACHE, DEFAULT_DOT_DIR, EXECUTABLE_NAME, EXTRA_PACKAGES_FILENAME,
+    },
+    Result,
 };
 
 fn dot_dir(name: &str) -> Option<PathBuf> {
@@ -12,6 +15,7 @@ fn dot_dir(name: &str) -> Option<PathBuf> {
 }
 #[cfg_attr(test, mockall::automock)]
 pub trait PycorsHomeProviderTrait {
+    fn home(&self) -> Result<PathBuf>;
     fn home_env_variable(&self) -> Option<OsString>;
     fn paths(&self) -> Option<OsString>;
 }
@@ -27,6 +31,9 @@ impl<P> PycorsHomeProviderTrait for PycorsPathsProvider<P>
 where
     P: PycorsHomeProviderTrait,
 {
+    fn home(&self) -> Result<PathBuf> {
+        self.path_provider.home()
+    }
     fn home_env_variable(&self) -> Option<OsString> {
         self.path_provider.home_env_variable()
     }
@@ -46,6 +53,9 @@ impl PycorsPathsProviderFromEnv {
 }
 
 impl PycorsHomeProviderTrait for PycorsPathsProviderFromEnv {
+    fn home(&self) -> Result<PathBuf> {
+        dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Error getting home directory"))
+    }
     fn home_env_variable(&self) -> Option<OsString> {
         env::var_os(constants::home_env_variable())
     }

--- a/src/utils/directory.rs
+++ b/src/utils/directory.rs
@@ -81,8 +81,7 @@ where
         // If we can't find our home directory, there is nothing we can do; simply panic.
         config_home_from_env
             .or(default_dot_dir)
-            .ok_or_else(|| anyhow::anyhow!("Cannot find {}' home directory", EXECUTABLE_NAME))
-            .unwrap()
+            .unwrap_or_else(|| panic!("Cannot find {}' home directory", EXECUTABLE_NAME))
     }
 
     pub fn default_extra_package_file(&self) -> PathBuf {

--- a/src/utils/directory.rs
+++ b/src/utils/directory.rs
@@ -152,12 +152,7 @@ pub mod tests {
 
     use super::*;
 
-    fn temp_dir() -> PathBuf {
-        env::temp_dir()
-            .join(EXECUTABLE_NAME)
-            .join("directory")
-            .join("tests")
-    }
+    use crate::tests::temp_dir;
 
     #[test]
     fn pycors_paths_from_env() {
@@ -241,7 +236,7 @@ pub mod tests {
         #[test]
         fn config_home_from_env_variable() {
             let home = default_home_full_path();
-            let pycors_home = temp_dir().join("config_home_from_env_variable");
+            let pycors_home = temp_dir("directory", "config_home_from_env_variable");
 
             let mocked_home = Ok(home);
             let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
@@ -283,7 +278,7 @@ pub mod tests {
         #[test]
         fn default_extra_package_file_from_env_variable() {
             let home = default_home_full_path();
-            let pycors_home = temp_dir().join("default_extra_package_file_from_env");
+            let pycors_home = temp_dir("directory", "default_extra_package_file_from_env");
             let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
 
             let mocked_home = Ok(home);
@@ -324,7 +319,7 @@ pub mod tests {
         #[test]
         fn cache_from_env_variable() {
             let home = default_home_full_path();
-            let pycors_home = temp_dir().join("cache_from_env");
+            let pycors_home = temp_dir("directory", "cache_from_env");
 
             let mocked_home = Ok(home);
             let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
@@ -366,7 +361,7 @@ pub mod tests {
         #[test]
         fn installed_from_env_variable() {
             let home = default_home_full_path();
-            let pycors_home = temp_dir().join("installed_from_env");
+            let pycors_home = temp_dir("directory", "installed_from_env");
 
             let mocked_home = Ok(home);
             let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
@@ -408,7 +403,7 @@ pub mod tests {
         #[test]
         fn logs_from_env_variable() {
             let home = default_home_full_path();
-            let pycors_home = temp_dir().join("logs_from_env");
+            let pycors_home = temp_dir("directory", "logs_from_env");
 
             let mocked_home = Ok(home);
             let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
@@ -449,7 +444,7 @@ pub mod tests {
 
         #[test]
         fn shims_from_env_variable() {
-            let pycors_home = temp_dir().join("shims_from_env");
+            let pycors_home = temp_dir("directory", "shims_from_env");
             let mocked_home = Ok(pycors_home.clone());
             let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
 
@@ -489,7 +484,7 @@ pub mod tests {
 
         #[test]
         fn downloaded_from_env_variable() {
-            let pycors_home = temp_dir().join("downloaded_from_env");
+            let pycors_home = temp_dir("directory", "downloaded_from_env");
             let mocked_home = Ok(pycors_home.clone());
             let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
 
@@ -529,7 +524,7 @@ pub mod tests {
 
         #[test]
         fn available_toolchain_from_env_variable() {
-            let pycors_home = temp_dir().join("available_toolchain_from_env");
+            let pycors_home = temp_dir("directory", "available_toolchain_from_env");
             let mocked_home = Ok(pycors_home.clone());
             let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
 
@@ -569,7 +564,7 @@ pub mod tests {
 
         #[test]
         fn extracted_from_env_variable() {
-            let pycors_home = temp_dir().join("extracted_from_env");
+            let pycors_home = temp_dir("directory", "extracted_from_env");
             let mocked_home = Ok(pycors_home.clone());
             let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
 
@@ -612,7 +607,7 @@ pub mod tests {
 
         #[test]
         fn install_dir_from_env_variable() {
-            let pycors_home = temp_dir().join("install_dir_from_env");
+            let pycors_home = temp_dir("directory", "install_dir_from_env");
             let mocked_home = Ok(pycors_home.clone());
             let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
             let version_str = "3.7.5";
@@ -660,7 +655,7 @@ pub mod tests {
 
         #[test]
         fn bin_dir_from_env_variable() {
-            let pycors_home = temp_dir().join("bin_dir_from_env");
+            let pycors_home = temp_dir("directory", "bin_dir_from_env");
             let mocked_home = Ok(pycors_home.clone());
             let mocked_pycors_home = Some(pycors_home.as_os_str().to_os_string());
             let version_str = "3.7.5";

--- a/src/utils/directory.rs
+++ b/src/utils/directory.rs
@@ -3,8 +3,9 @@ use std::{env, ffi::OsString, path::PathBuf};
 use dirs::home_dir;
 use semver::Version;
 
-use crate::{
-    constants, AVAILABLE_TOOLCHAIN_CACHE, DEFAULT_DOT_DIR, EXECUTABLE_NAME, EXTRA_PACKAGES_FILENAME,
+use crate::constants::{
+    self, AVAILABLE_TOOLCHAIN_CACHE, DEFAULT_DOT_DIR, EXECUTABLE_NAME,
+    EXTRA_PACKAGES_FILENAME,
 };
 
 fn dot_dir(name: &str) -> Option<PathBuf> {
@@ -149,7 +150,7 @@ pub mod tests {
 
     fn temp_dir() -> PathBuf {
         env::temp_dir()
-            .join(crate::constants::EXECUTABLE_NAME)
+            .join(EXECUTABLE_NAME)
             .join("directory")
             .join("tests")
     }

--- a/src/utils/directory.rs
+++ b/src/utils/directory.rs
@@ -197,8 +197,12 @@ pub mod tests {
         use super::*;
         use crate::constants::home_env_variable;
 
+        fn default_home_full_path() -> PathBuf {
+            dirs::home_dir().unwrap()
+        }
+
         fn default_dot_full_path() -> PathBuf {
-            dirs::home_dir().unwrap().join(DEFAULT_DOT_DIR)
+            default_home_full_path().join(DEFAULT_DOT_DIR)
         }
 
         #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,7 +1,7 @@
 use std::{env, fs, path::PathBuf};
 
 use assert_cmd::{assert::OutputAssertExt, Command};
-use predicates::{boolean::PredicateBooleanExt, prelude::predicate};
+use predicates::prelude::*;
 
 use pycors::constants::{home_env_variable, EXECUTABLE_NAME};
 
@@ -32,11 +32,14 @@ mod integration {
 
         assert_output
             .success()
-            .stdout(format!(
-                "{} {}\n",
-                env!("CARGO_PKG_NAME"),
-                env!("CARGO_PKG_VERSION")
-            ))
+            .stdout(
+                predicate::str::similar(format!(
+                    "{} {}\n",
+                    env!("CARGO_PKG_NAME"),
+                    env!("CARGO_PKG_VERSION")
+                ))
+                .normalize(),
+            )
             .stderr("");
     }
 
@@ -65,6 +68,7 @@ mod integration {
                     env!("CARGO_PKG_NAME"),
                     env!("CARGO_PKG_VERSION")
                 ))
+                .normalize()
                 .and(predicate::str::contains("USAGE:"))
                 .and(predicate::str::contains("FLAGS:"))
                 .and(predicate::str::contains("SUBCOMMANDS:")),
@@ -99,11 +103,11 @@ mod integration {
         #[rustfmt::skip]
         assert_output
             .success()
-            .stdout(
+            .stdout(predicate::str::similar(
 "+--------+---------+---------------------+----------+
 | Active | Version | Installed by pycors | Location |
 +--------+---------+---------------------+----------+
-",
+").normalize()
             )
         // .stderr("")
         ;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3,8 +3,12 @@ use std::{env, fs, path::PathBuf};
 use assert_cmd::{assert::OutputAssertExt, Command};
 use predicates::{boolean::PredicateBooleanExt, prelude::predicate};
 
+use pycors::constants::{home_env_variable, EXECUTABLE_NAME};
+
 pub fn temp_dir(subdir: &str) -> PathBuf {
-    let dir = env::temp_dir().join("pycors").join("integration_tests");
+    let dir = env::temp_dir()
+        .join(EXECUTABLE_NAME)
+        .join("integration_tests");
 
     if !dir.exists() {
         fs::create_dir_all(&dir).unwrap();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -94,11 +94,13 @@ mod integration {
     #[test]
     fn list_with_empty_dir() {
         let pycors_home = temp_dir("list_with_empty_dir");
+        let cwd = pycors_home.join("current_dir");
         let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
         let output = cmd
             .arg("list")
             .env(home_env_variable(), &pycors_home)
             .env("PATH", pycors_home.join("usr_bin"))
+            .current_dir(&cwd) // Change to a clean directory without a '.python-version'
             .unwrap();
         let assert_output = output.assert();
         assert_output

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -304,7 +304,6 @@ mod integration {
         let _location_380_dir = installed(&pycors_home, "3.8.0", false).unwrap();
         let location_375_dir = installed(&pycors_home, "3.7.5", true).unwrap();
         let _location_374_dir = installed(&pycors_home, "3.7.4", true).unwrap();
-        fs::create_dir_all(&cwd).unwrap();
         select("=3.8.0", &cwd);
 
         let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -202,7 +202,6 @@ mod integration {
     fn list_selected_but_not_installed() {
         let pycors_home = temp_dir("list_selected_but_not_installed");
         let cwd = pycors_home.join("current_dir");
-        fs::create_dir_all(&cwd).unwrap();
         select("=3.7.5", &cwd);
 
         let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,0 +1,84 @@
+use std::{env, fs, path::PathBuf};
+
+use assert_cmd::{assert::OutputAssertExt, Command};
+use predicates::{boolean::PredicateBooleanExt, prelude::predicate};
+
+pub fn temp_dir(subdir: &str) -> PathBuf {
+    let dir = env::temp_dir().join("pycors").join("integration_tests");
+
+    if !dir.exists() {
+        fs::create_dir_all(&dir).unwrap();
+    }
+    let dir = dir.canonicalize().unwrap().join(subdir);
+
+    if dir.exists() {
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    fs::create_dir_all(&dir).unwrap();
+
+    dir
+}
+
+mod integration {
+    use super::*;
+
+    fn test_version(output: std::process::Output) {
+        let assert_output = output.assert();
+
+        assert_output
+            .success()
+            .stdout(format!(
+                "{} {}\n",
+                env!("CARGO_PKG_NAME"),
+                env!("CARGO_PKG_VERSION")
+            ))
+            .stderr("");
+    }
+
+    #[test]
+    fn version_long() {
+        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+        let output = cmd.arg("--version").unwrap();
+        test_version(output);
+    }
+
+    #[test]
+    fn version_short() {
+        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+        let output = cmd.arg("-V").unwrap();
+        test_version(output);
+    }
+
+    fn test_help(output: std::process::Output) {
+        let assert_output = output.assert();
+
+        assert_output
+            .success()
+            .stdout(
+                predicate::str::starts_with(format!(
+                    "{} {}\n",
+                    env!("CARGO_PKG_NAME"),
+                    env!("CARGO_PKG_VERSION")
+                ))
+                .and(predicate::str::contains("USAGE:"))
+                .and(predicate::str::contains("FLAGS:"))
+                .and(predicate::str::contains("SUBCOMMANDS:")),
+            )
+            .stderr("");
+    }
+
+    #[test]
+    fn help_long() {
+        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+        let output = cmd.arg("--help").unwrap();
+        test_help(output);
+    }
+
+    #[test]
+    fn help_short() {
+        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+        let output = cmd.arg("-h").unwrap();
+        test_help(output);
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -197,4 +197,33 @@ mod integration {
         // .stderr("")
         ;
     }
+
+    #[test]
+    fn list_selected_but_not_installed() {
+        let pycors_home = temp_dir("list_selected_but_not_installed");
+        let cwd = pycors_home.join("current_dir");
+        fs::create_dir_all(&cwd).unwrap();
+        select("=3.7.5", &cwd);
+
+        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+        let output = cmd
+            .arg("list")
+            .env(home_env_variable(), &pycors_home)
+            .env("PATH", pycors_home.join("usr_bin"))
+            .current_dir(&cwd)
+            .unwrap();
+        let assert_output = output.assert();
+        assert_output
+            .success()
+            .stdout(predicate::str::similar(indoc!("
+                +--------+---------+---------------------+----------+
+                | Active | Version | Installed by pycors | Location |
+                +--------+---------+---------------------+----------+
+                |   ✗    |  3.7.5  |                     |          |
+                +--------+---------+---------------------+----------+"
+            )).trim().normalize()
+            )
+        // .stderr("")
+        ;
+    }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -322,4 +322,123 @@ mod integration {
             .stdout(predicate::str::similar(location_375_dir).trim())
             .stderr("");
     }
+
+    #[test]
+    fn select_from_none_exact() {
+        let pycors_home = temp_dir("select_from_none_exact");
+        let cwd = pycors_home.join("current_dir");
+        let _location_375_dir = installed(&pycors_home, "3.7.5", true).unwrap();
+        fs::create_dir_all(&cwd).unwrap();
+
+        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+        let output = cmd
+            .arg("select")
+            .arg("=3.7.5")
+            .env(home_env_variable(), &pycors_home)
+            .env("PATH", pycors_home.join("usr_bin"))
+            .env("RUST_LOG", "")
+            .current_dir(&cwd)
+            .unwrap();
+        let assert_output = output.assert();
+        assert_output.success().stdout("").stderr("");
+
+        let file_content = fs::read_to_string(cwd.join(TOOLCHAIN_FILE)).unwrap();
+        assert_eq!(file_content.trim(), "= 3.7.5");
+    }
+
+    #[test]
+    fn select_from_none_tilde() {
+        let pycors_home = temp_dir("select_from_none_tilde");
+        let cwd = pycors_home.join("current_dir");
+        let _location_375_dir = installed(&pycors_home, "3.7.5", true).unwrap();
+        fs::create_dir_all(&cwd).unwrap();
+
+        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+        let output = cmd
+            .arg("select")
+            .arg("~3.7")
+            .env(home_env_variable(), &pycors_home)
+            .env("PATH", pycors_home.join("usr_bin"))
+            .env("RUST_LOG", "")
+            .current_dir(&cwd)
+            .unwrap();
+        let assert_output = output.assert();
+        assert_output.success().stdout("").stderr("");
+
+        let file_content = fs::read_to_string(cwd.join(TOOLCHAIN_FILE)).unwrap();
+        assert_eq!(file_content.trim(), "= 3.7.5");
+    }
+
+    #[test]
+    fn select_from_some_exact() {
+        let pycors_home = temp_dir("select_from_some_exact");
+        let cwd = pycors_home.join("current_dir");
+        let _location_375_dir = installed(&pycors_home, "3.7.5", true).unwrap();
+        let _location_380_dir = installed(&pycors_home, "3.8.0", true).unwrap();
+        select("=3.8.0", &cwd);
+
+        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+        let output = cmd
+            .arg("select")
+            .arg("=3.7.5")
+            .env(home_env_variable(), &pycors_home)
+            .env("PATH", pycors_home.join("usr_bin"))
+            .env("RUST_LOG", "")
+            .current_dir(&cwd)
+            .unwrap();
+        let assert_output = output.assert();
+        assert_output.success().stdout("").stderr("");
+
+        let file_content = fs::read_to_string(cwd.join(TOOLCHAIN_FILE)).unwrap();
+        assert_eq!(file_content.trim(), "= 3.7.5");
+    }
+
+    #[test]
+    fn select_from_none_not_installed() {
+        let pycors_home = temp_dir("select_from_none_not_installed");
+        let cwd = pycors_home.join("current_dir");
+        let _location_380_dir = installed(&pycors_home, "3.8.0", true).unwrap();
+        fs::create_dir_all(&cwd).unwrap();
+
+        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+        let output = cmd
+            .arg("select")
+            .arg("=3.7.5")
+            .env(home_env_variable(), &pycors_home)
+            .env("PATH", pycors_home.join("usr_bin"))
+            .env("RUST_LOG", "")
+            .current_dir(&cwd);
+        let assert_output = output.assert();
+        assert_output
+            .failure()
+            .stdout("")
+            .stderr(predicate::str::similar("Error: Python version =3.7.5 not found!").trim());
+
+        assert!(!cwd.join(TOOLCHAIN_FILE).exists());
+    }
+
+    #[test]
+    fn select_from_some_not_installed() {
+        let pycors_home = temp_dir("select_from_some_not_installed");
+        let cwd = pycors_home.join("current_dir");
+        let _location_380_dir = installed(&pycors_home, "3.8.0", true).unwrap();
+        select("= 3.8.0", &cwd);
+
+        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+        let output = cmd
+            .arg("select")
+            .arg("=3.7.5")
+            .env(home_env_variable(), &pycors_home)
+            .env("PATH", pycors_home.join("usr_bin"))
+            .env("RUST_LOG", "")
+            .current_dir(&cwd);
+        let assert_output = output.assert();
+        assert_output
+            .failure()
+            .stdout("")
+            .stderr(predicate::str::similar("Error: Python version =3.7.5 not found!").trim());
+
+        let file_content = fs::read_to_string(cwd.join(TOOLCHAIN_FILE)).unwrap();
+        assert_eq!(file_content.trim(), "= 3.8.0");
+    }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,6 +1,7 @@
 use std::{env, fs, path::PathBuf};
 
 use assert_cmd::{assert::OutputAssertExt, Command};
+use indoc::indoc;
 use predicates::prelude::*;
 
 use pycors::constants::{home_env_variable, EXECUTABLE_NAME};
@@ -100,14 +101,13 @@ mod integration {
             .env("PATH", pycors_home.join("usr_bin"))
             .unwrap();
         let assert_output = output.assert();
-        #[rustfmt::skip]
         assert_output
             .success()
-            .stdout(predicate::str::similar(
-"+--------+---------+---------------------+----------+
-| Active | Version | Installed by pycors | Location |
-+--------+---------+---------------------+----------+
-").normalize()
+            .stdout(predicate::str::similar(indoc!("
+                +--------+---------+---------------------+----------+
+                | Active | Version | Installed by pycors | Location |
+                +--------+---------+---------------------+----------+"
+            )).trim().normalize()
             )
         // .stderr("")
         ;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -93,7 +93,7 @@ mod integration {
 
     #[test]
     fn list_with_empty_dir() {
-        let pycors_home = temp_dir("list");
+        let pycors_home = temp_dir("list_with_empty_dir");
         let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
         let output = cmd
             .arg("list")

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -85,4 +85,27 @@ mod integration {
         let output = cmd.arg("-h").unwrap();
         test_help(output);
     }
+
+    #[test]
+    fn list_with_empty_dir() {
+        let pycors_home = temp_dir("list");
+        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+        let output = cmd
+            .arg("list")
+            .env(home_env_variable(), &pycors_home)
+            .env("PATH", pycors_home.join("usr_bin"))
+            .unwrap();
+        let assert_output = output.assert();
+        #[rustfmt::skip]
+        assert_output
+            .success()
+            .stdout(
+"+--------+---------+---------------------+----------+
+| Active | Version | Installed by pycors | Location |
++--------+---------+---------------------+----------+
+",
+            )
+        // .stderr("")
+        ;
+    }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -225,4 +225,102 @@ mod integration {
         // .stderr("")
         ;
     }
+
+    #[test]
+    fn path_none() {
+        let pycors_home = temp_dir("path_none");
+        let cwd = pycors_home.join("current_dir");
+        fs::create_dir_all(&cwd).unwrap();
+        // select("=3.7.5", &cwd);
+
+        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+        let output = cmd
+            .arg("path")
+            .env(home_env_variable(), &pycors_home)
+            .env("PATH", pycors_home.join("usr_bin"))
+            .current_dir(&cwd)
+            .unwrap();
+        let assert_output = output.assert();
+        assert_output
+            .success()
+            .stdout(predicate::str::similar("\n").normalize())
+        // .stderr("")
+        ;
+    }
+
+    #[test]
+    fn path_some_select() {
+        let pycors_home = temp_dir("path_some_select");
+        let cwd = pycors_home.join("current_dir");
+        let _location_380_dir = installed(&pycors_home, "3.8.0", false).unwrap();
+        let location_375_dir = installed(&pycors_home, "3.7.5", true).unwrap();
+        let _location_374_dir = installed(&pycors_home, "3.7.4", true).unwrap();
+        fs::create_dir_all(&cwd).unwrap();
+        select("=3.7.5", &cwd);
+
+        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+        let output = cmd
+            .arg("path")
+            .env(home_env_variable(), &pycors_home)
+            .env("PATH", pycors_home.join("usr_bin"))
+            .env("RUST_LOG", "")
+            .current_dir(&cwd)
+            .unwrap();
+        let assert_output = output.assert();
+        assert_output
+            .success()
+            .stdout(predicate::str::similar(location_375_dir).trim())
+            .stderr("");
+    }
+
+    #[test]
+    fn path_some_latest() {
+        let pycors_home = temp_dir("path_some_latest");
+        let cwd = pycors_home.join("current_dir");
+        let location_380_dir = installed(&pycors_home, "3.8.0", false).unwrap();
+        let _location_375_dir = installed(&pycors_home, "3.7.5", true).unwrap();
+        let _location_374_dir = installed(&pycors_home, "3.7.4", true).unwrap();
+        fs::create_dir_all(&cwd).unwrap();
+
+        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+        let output = cmd
+            .arg("path")
+            .env(home_env_variable(), &pycors_home)
+            .env("PATH", pycors_home.join("usr_bin"))
+            .env("RUST_LOG", "")
+            .current_dir(&cwd)
+            .unwrap();
+        let assert_output = output.assert();
+        assert_output
+            .success()
+            .stdout(predicate::str::similar(location_380_dir).trim())
+            .stderr("");
+    }
+
+    #[test]
+    fn path_some_version_overwrite() {
+        let pycors_home = temp_dir("path_some_version_overwrite");
+        let cwd = pycors_home.join("current_dir");
+        let _location_380_dir = installed(&pycors_home, "3.8.0", false).unwrap();
+        let location_375_dir = installed(&pycors_home, "3.7.5", true).unwrap();
+        let _location_374_dir = installed(&pycors_home, "3.7.4", true).unwrap();
+        fs::create_dir_all(&cwd).unwrap();
+        select("=3.8.0", &cwd);
+
+        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+        let output = cmd
+            .arg("path")
+            .arg("--version")
+            .arg("~3.7")
+            .env(home_env_variable(), &pycors_home)
+            .env("PATH", pycors_home.join("usr_bin"))
+            .env("RUST_LOG", "")
+            .current_dir(&cwd)
+            .unwrap();
+        let assert_output = output.assert();
+        assert_output
+            .success()
+            .stdout(predicate::str::similar(location_375_dir).trim())
+            .stderr("");
+    }
 }


### PR DESCRIPTION
Add integration tests using `assert_cmd` crate. At least one bug on Windows found (fa38278).

Commands covered:

* [ ] `autocomplete`
* [x] `help`
* [ ] `install`
* [x] `list`
* [x] `path`
* [ ] `run`
* [x] `select`
* [ ] `setup`
* [x] `version`